### PR TITLE
Add CODEOWNERS and narrow workflow token permissions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: smigolsmigol

--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -7,11 +7,12 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @smigolsmigol

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+security@llmkit.dev.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   <a href="https://www.npmjs.com/package/@f3d1/llmkit-sdk"><img src="https://img.shields.io/npm/v/%40f3d1/llmkit-sdk?label=npm&color=blue" alt="npm" /></a>
   <a href="https://github.com/smigolsmigol/llmkit/tree/main/packages/mcp-server"><img src="https://img.shields.io/badge/MCP-Registry-blue" alt="MCP" /></a>
   <a href="https://lobehub.com/mcp/smigolsmigol-llmkit"><img src="https://img.shields.io/badge/LobeHub-A_Grade-green" alt="LobeHub MCP" /></a>
+  <a href="https://www.npmjs.com/package/@f3d1/llmkit-mcp-server"><img src="https://img.shields.io/npm/dw/@f3d1/llmkit-mcp-server?label=npm%20downloads" alt="npm downloads" /></a>
+  <a href="https://pypi.org/project/llmkit-sdk/"><img src="https://img.shields.io/pypi/dm/llmkit-sdk?label=PyPI%20downloads" alt="PyPI downloads" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Make repository ownership explicit and reduce workflow token permissions.

## What changed

- Add CODEOWNERS for repository review routing.
- Move `actions: write` permission from workflow scope to the job that needs it.
- Correct the code-of-conduct enforcement contact.
- Add repository funding metadata and package download badges.

## Verification

- Repository CI, CodeQL, and Semgrep passed on the merged head.

## Review focus

Ownership and least-privilege workflow configuration. Badges and metadata do not establish security quality by themselves.