### PR TITLE
Generate CycloneDX SBOMs for releases

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,35 @@
+name: SBOM
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: generate CycloneDX SBOM
+        uses: CycloneDX/gh-node-module-generatebom@d43a3643a67e61f459884ac1452fa9a0cb1f4ab8 # v1
+        with:
+          path: .
+          output: sbom.cdx.json
+
+      - name: upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6db9a6b7c67d0a148c5aea33f8735 # v4
+        with:
+          name: sbom
+          path: sbom.cdx.json
+
+      - name: attach SBOM to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" sbom.cdx.json --clobber


### PR DESCRIPTION
## Summary

Generate a CycloneDX software bill of materials for tagged releases.

## What changed

- Add a release-triggered SBOM workflow.
- Upload the generated SBOM as a release artifact.

## Verification

- Repository CI, CodeQL, and Semgrep passed on the merged head.

## Review focus

Artifact generation and release attachment. An SBOM improves dependency visibility; it is not a compliance certification by itself.