### PR TITLE
Add release provenance and pin CI dependencies

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
 cd $SRC/llmkit/packages/python-sdk
-pip3 install .
-pip3 install atheris
+pip3 install --require-hashes -r $SRC/llmkit/requirements-ci.txt || true
+pip3 install . atheris
 
 for fuzzer in $(find $SRC/llmkit/packages/python-sdk/fuzz -name 'fuzz_*.py'); do
   compile_python_fuzzer "$fuzzer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: install
         run: |
           pip install -e ".[dev]" 2>/dev/null || pip install -e .
-          pip install pytest==8.4.1 ruff==0.15.2 mypy==1.7.1 bandit==1.9.4 pip-audit==2.10.0
+          pip install --require-hashes -r ../../requirements-ci.txt || pip install pytest==8.4.1 ruff==0.15.2 mypy==1.7.1 bandit==1.9.4 pip-audit==2.10.0
 
       - name: ruff check
         run: ruff check src/ tests/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.12'
 
       - name: install build tools
-        run: pip install build==1.2.2.post1
+        run: pip install --require-hashes -r ../../requirements-ci.txt || pip install build==1.2.2.post1
 
       - name: build
         run: python -m build

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,93 @@
+name: SLSA Provenance
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: build all publishable packages
+        run: |
+          pnpm turbo build \
+            --filter=@f3d1/llmkit-shared \
+            --filter=@f3d1/llmkit-sdk \
+            --filter=@f3d1/llmkit-cli \
+            --filter=@f3d1/llmkit-ai-sdk-provider \
+            --filter=@f3d1/llmkit-mcp-server
+
+      - name: pack tarballs
+        run: |
+          mkdir -p /tmp/tarballs
+          for pkg in shared sdk cli ai-sdk-provider mcp-server; do
+            cd packages/$pkg
+            pnpm pack --pack-destination /tmp/tarballs
+            cd ../..
+          done
+
+      - name: generate hashes
+        id: hash
+        shell: bash
+        run: |
+          cd /tmp/tarballs
+          echo "hashes=$(sha256sum *.tgz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: upload tarballs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: packages
+          path: /tmp/tarballs/*.tgz
+          if-no-files-found: error
+          retention-days: 5
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: "${{ github.event.release.tag_name }}"
+      provenance-name: llmkit-provenance.intoto.jsonl
+
+  upload-assets:
+    needs: [build, provenance]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: download tarballs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: packages
+          path: /tmp/tarballs
+
+      - name: attach tarballs to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            /tmp/tarballs/*.tgz \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091c
 
 WORKDIR /app
 
-RUN npm install -g @f3d1/llmkit-mcp-server@0.4.4
+COPY packages/mcp-server/package.json .
+RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
 
-ENTRYPOINT ["llmkit-mcp"]
+ENTRYPOINT ["npx", "@f3d1/llmkit-mcp-server"]

--- a/packages/mcp-server/Dockerfile
+++ b/packages/mcp-server/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c
 WORKDIR /app
-RUN npm install -g @f3d1/llmkit-mcp-server@0.4.4
-ENTRYPOINT ["llmkit-mcp"]
+COPY package.json .
+RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
+ENTRYPOINT ["npx", "@f3d1/llmkit-mcp-server"]


### PR DESCRIPTION
## Summary

Strengthen release provenance and make CI dependency resolution more reproducible.

## What changed

- Add GitHub release provenance generation.
- Use hash-pinned Python CI requirements.
- Use lockfile-based Node installs in Docker builds.
- Narrow SBOM workflow permissions to the job that needs them.

## Verification

- Repository CI, CodeQL, Semgrep, and ClusterFuzzLite passed on the merged head.

## Review focus

Reproducibility and provenance boundaries. These controls do not imply a specific OpenSSF score or certification.