### PR TITLE
phase 5: dependabot auto-merge shim

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,11 @@
+name: dependabot-automerge
+on: pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  call:
+    uses: smigolsmigol/.github/.github/workflows/dependabot-automerge.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

Wires llmkit into the org-level Dependabot auto-merge reusable workflow at `smigolsmigol/.github/.github/workflows/dependabot-automerge.yml`. Patch + minor bumps auto-merge once CI passes; major and direct-production minor bumps stay open for human review.

Part of the chad foundation rollout (phases 1-9 across the f3d1 org).

## Test plan

- [ ] Wait for next Dependabot PR (one of the existing ones in the queue)
- [ ] Confirm the workflow approves + sets auto-merge
- [ ] Confirm CI is the gating step (no merge before checks pass)