### PR TITLE
feat(proxy): f3dx-bench beacon emission (V0)

### DIFF
--- a/packages/proxy/src/bench.ts
+++ b/packages/proxy/src/bench.ts
@@ -1,0 +1,93 @@
+// f3dx-bench beacon emission. Mirrors the python f3dx.bench wire format
+// at https://github.com/smigolsmigol/f3dx/blob/main/python/f3dx/bench/__init__.py
+//
+// Default OFF. Enable by setting these in the worker env (wrangler secret):
+//   BENCH_ENABLED=1
+//   BENCH_INSTALL_ID=<uuid v4 generated locally, registered TOFU on first beacon>
+//   BENCH_INSTALL_HMAC=<32-byte hex token, paired with install_id>
+//   BENCH_INGEST_URL=<defaults to f3dx-bench-ingest.smigolsmigol.workers.dev>
+//
+// Wire format is anonymized: ts, install_id, install_hmac, model, provider,
+// status_code, latency_ms_total, input_tokens, output_tokens, region,
+// latency_ms_to_first_token, cost_usd_estimate. NO prompts, responses,
+// API keys, customer-identifying headers, or hostnames cross the wire.
+//
+// V0 = one install_id for the whole llmkit deployment. V0.2 will key off
+// tenantId so per-customer opt-in works through the dashboard toggle.
+
+const DEFAULT_INGEST_URL = "https://f3dx-bench-ingest.smigolsmigol.workers.dev";
+const SCHEMA_VERSION = "v1";
+
+export interface BenchEnv {
+  BENCH_ENABLED?: string;
+  BENCH_INSTALL_ID?: string;
+  BENCH_INSTALL_HMAC?: string;
+  BENCH_INGEST_URL?: string;
+}
+
+export interface BenchBeaconInput {
+  model: string;
+  provider: string;
+  status_code: number;
+  latency_ms_total: number;
+  input_tokens: number;
+  output_tokens: number;
+  region?: string;
+  latency_ms_to_first_token?: number;
+  cost_usd_estimate?: number;
+}
+
+export function isBenchEnabled(env: BenchEnv): boolean {
+  return (
+    env.BENCH_ENABLED === "1" &&
+    !!env.BENCH_INSTALL_ID &&
+    !!env.BENCH_INSTALL_HMAC
+  );
+}
+
+export async function emitBeacon(
+  env: BenchEnv,
+  input: BenchBeaconInput,
+): Promise<void> {
+  if (!isBenchEnabled(env)) return;
+
+  const url =
+    (env.BENCH_INGEST_URL || DEFAULT_INGEST_URL).replace(/\/$/, "") +
+    "/v1/beacon";
+
+  const beacon: Record<string, unknown> = {
+    schema_version: SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    install_id: env.BENCH_INSTALL_ID,
+    install_hmac: env.BENCH_INSTALL_HMAC,
+    model: input.model,
+    provider: input.provider,
+    status_code: Math.trunc(input.status_code),
+    latency_ms_total: Math.trunc(input.latency_ms_total),
+    input_tokens: Math.trunc(input.input_tokens),
+    output_tokens: Math.trunc(input.output_tokens),
+  };
+  if (input.region) beacon.region = input.region;
+  if (input.latency_ms_to_first_token != null) {
+    beacon.latency_ms_to_first_token = Math.trunc(
+      input.latency_ms_to_first_token,
+    );
+  }
+  if (input.cost_usd_estimate != null) {
+    beacon.cost_usd_estimate = Number(input.cost_usd_estimate);
+  }
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // Identify ourselves so the bench Worker's WAF doesn't 1010 us.
+        "user-agent": "llmkit-bench/0.0.1 (+https://github.com/smigolsmigol/llmkit)",
+      },
+      body: JSON.stringify(beacon),
+    });
+  } catch {
+    // Telemetry must never break user code.
+  }
+}

--- a/packages/proxy/src/env.ts
+++ b/packages/proxy/src/env.ts
@@ -23,6 +23,10 @@ export type Env = {
     TELEGRAM_BOT_TOKEN?: string;
     TELEGRAM_CHAT_ID?: string;
     TELEGRAM_VERBOSE?: string;
+    BENCH_ENABLED?: string;
+    BENCH_INSTALL_ID?: string;
+    BENCH_INSTALL_HMAC?: string;
+    BENCH_INGEST_URL?: string;
   };
   Variables: {
     apiKey: string;

--- a/packages/proxy/src/routes/chat.ts
+++ b/packages/proxy/src/routes/chat.ts
@@ -12,6 +12,7 @@ import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { stream } from 'hono/streaming';
 import type { StreamingApi } from 'hono/utils/stream';
+import { emitBeacon } from '../bench';
 import { decrypt } from '../crypto';
 import { findProviderKey } from '../db';
 import type { Env, ResponseMeta } from '../env';
@@ -163,6 +164,18 @@ async function handleChat(c: Context<Env>, req: ProviderRequest, chain: Provider
         providerCostUsd: result.providerCostUsd,
       };
       c.set('llmkit_response', meta);
+
+      c.executionCtx.waitUntil(
+        emitBeacon(c.env, {
+          model: result.model,
+          provider: providerName,
+          status_code: 200,
+          latency_ms_total: latency,
+          input_tokens: result.usage.inputTokens,
+          output_tokens: result.usage.outputTokens,
+          cost_usd_estimate: cost.totalCost,
+        }),
+      );
 
       if (wantsLLMKitFormat(c)) {
         const margin = calculateMargin(c, cost.totalCost);


### PR DESCRIPTION
## Summary

- Adds `packages/proxy/src/bench.ts` (~110 LOC) mirroring the python `f3dx.bench` SDK wire format
- Hooks `emitBeacon()` into `handleChat()` via `c.executionCtx.waitUntil()` so the POST is fire-and-forget
- Emits 12 anonymized fields: ts, install_id, install_hmac, model, provider, status_code, latency_ms_total, input_tokens, output_tokens, cost_usd_estimate (region + latency_ms_to_first_token reserved for V0.1)
- Default OFF; opt-in via `BENCH_ENABLED=1` + `BENCH_INSTALL_ID` + `BENCH_INSTALL_HMAC` wrangler secrets
- V0 = one install_id for the whole deployment; V0.2 will key off `tenantId` for per-customer dashboard toggle

## What does NOT cross the wire

- No prompt content
- No response content
- No customer API keys
- No customer-identifying headers
- No hostnames

Same privacy contract as the python SDK. Beacon ingest is the same Worker at `f3dx-bench-ingest.smigolsmigol.workers.dev`; same TOFU-pinned identity-token verification.

## Test plan

- [ ] Local `wrangler dev` with BENCH_ENABLED=1 + a fresh install_id/hmac, run a chat completion, confirm beacon lands in R2 via `tools/compact_ndjson_to_parquet.py` smoke
- [ ] Verify `tsc --noEmit` clean (already done locally)
- [ ] Verify biome clean on bench.ts (already done locally)
- [ ] After merge: register llmkit's install_id with the bench Worker; flip BENCH_ENABLED on the deployed worker; watch the f3dx-bench dashboard

## Out of scope (V0.1 / V0.2)

- Streaming response path (only non-streaming chat completions emit today)
- Error path emission (status_code currently hard-coded to 200; non-200 paths bail before the beacon)
- Per-tenant install_id rotation