### PR TITLE
fix(web): redirect public hosts to HTTPS

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -33,7 +33,8 @@
     "packages/dashboard": {
       "entry": [
         "open-next.config.ts",
-        "test/*.mjs"
+        "test/*.mjs",
+        "test/fixtures/*.ts"
       ],
       "ignoreDependencies": ["class-variance-authority"],
       "ignore": [

--- a/packages/dashboard/cloudflare-worker.ts
+++ b/packages/dashboard/cloudflare-worker.ts
@@ -1,7 +1,10 @@
 // biome-ignore lint/suspicious/noTsIgnore: The OpenNext handler is generated before Wrangler runs.
 // @ts-ignore The OpenNext handler is generated before Wrangler runs.
 import openNextHandler from './.open-next/worker.js';
-import { classifyRecoveryPath } from './src/lib/public-recovery';
+import {
+  classifyRecoveryPath,
+  createHttpsRedirectResponse,
+} from './src/lib/public-recovery';
 
 const SECURITY_HEADERS = {
   'Content-Security-Policy':
@@ -37,6 +40,12 @@ function withHeaders(response: Response, extraHeaders: Record<string, string> = 
 export default {
   async fetch(request: Request, env: unknown, context: unknown): Promise<Response> {
     const requestUrl = new URL(request.url);
+    const httpsRedirectResponse = createHttpsRedirectResponse(requestUrl);
+
+    if (httpsRedirectResponse) {
+      return withHeaders(httpsRedirectResponse);
+    }
+
     const boundary = classifyRecoveryPath(requestUrl.pathname);
 
     if (boundary === 'blocked-api') {

--- a/packages/dashboard/src/lib/public-recovery.ts
+++ b/packages/dashboard/src/lib/public-recovery.ts
@@ -10,7 +10,33 @@ export const RECOVERY_BLOCKED_API_PREFIXES = [
   '/api/pricing',
 ] as const;
 
+export const RECOVERY_WEB_HOSTS = ['llmkit.sh', 'www.llmkit.sh'] as const;
+
 export type RecoveryBoundary = 'public' | 'blocked-ui' | 'blocked-api';
+
+export function getHttpsRedirectUrl(requestUrl: URL): string | null {
+  if (
+    requestUrl.protocol !== 'http:' ||
+    !RECOVERY_WEB_HOSTS.some((hostname) => hostname === requestUrl.hostname)
+  ) {
+    return null;
+  }
+
+  return `https://${requestUrl.hostname}${requestUrl.pathname}${requestUrl.search}`;
+}
+
+export function createHttpsRedirectResponse(requestUrl: URL): Response | null {
+  const location = getHttpsRedirectUrl(requestUrl);
+
+  if (!location) {
+    return null;
+  }
+
+  return new Response(null, {
+    status: 308,
+    headers: { Location: location },
+  });
+}
 
 function matchesPathPrefix(pathname: string, prefix: string): boolean {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);

--- a/packages/dashboard/test/fixtures/https-redirect-worker.ts
+++ b/packages/dashboard/test/fixtures/https-redirect-worker.ts
@@ -1,0 +1,7 @@
+import { createHttpsRedirectResponse } from '../../src/lib/public-recovery';
+
+export default {
+  fetch(request: Request): Response {
+    return createHttpsRedirectResponse(new URL(request.url)) ?? new Response(null, { status: 204 });
+  },
+};

--- a/packages/dashboard/test/https-redirect-runtime-test.mjs
+++ b/packages/dashboard/test/https-redirect-runtime-test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { createTestHarness } from 'wrangler';
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+const server = createTestHarness({
+  root: packageRoot,
+  workers: [
+    {
+      config: {
+        name: 'llmkit-https-redirect-runtime',
+        main: 'test/fixtures/https-redirect-worker.ts',
+        compatibility_date: '2026-07-17',
+        compatibility_flags: ['nodejs_compat', 'global_fetch_strictly_public'],
+      },
+    },
+  ],
+});
+
+try {
+  await server.listen();
+  const worker = server.getWorker();
+
+  for (const [source, destination] of [
+    ['http://llmkit.sh/', 'https://llmkit.sh/'],
+    ['http://www.llmkit.sh/docs?provider=openai', 'https://www.llmkit.sh/docs?provider=openai'],
+  ]) {
+    const response = await worker.fetch(source, { redirect: 'manual' });
+    assert.equal(response.status, 308, source);
+    assert.equal(response.headers.get('location'), destination, source);
+  }
+
+  for (const source of [
+    'https://llmkit.sh/',
+    'http://api.llmkit.sh/health',
+    'http://llmkit.sh.example.com/',
+    'http://llmkit-web-staging.workers.dev/',
+  ]) {
+    const response = await worker.fetch(source, { redirect: 'manual' });
+    assert.equal(response.status, 204, source);
+    assert.equal(response.headers.get('location'), null, source);
+  }
+} finally {
+  await server.close();
+}
+
+console.log('HTTPS_REDIRECT_RUNTIME PASS (workerd 308 plus exact-host non-capture)');

--- a/packages/dashboard/test/recovery-boundary-test.mjs
+++ b/packages/dashboard/test/recovery-boundary-test.mjs
@@ -3,8 +3,10 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   classifyRecoveryPath,
+  getHttpsRedirectUrl,
   RECOVERY_BLOCKED_API_PREFIXES,
   RECOVERY_BLOCKED_UI_PREFIXES,
+  RECOVERY_WEB_HOSTS,
 } from '../src/lib/public-recovery.ts';
 
 const packageRoot = fileURLToPath(new URL('..', import.meta.url));
@@ -35,6 +37,25 @@ assert.deepEqual(RECOVERY_BLOCKED_API_PREFIXES, [
   '/api/export',
   '/api/pricing',
 ]);
+assert.deepEqual(RECOVERY_WEB_HOSTS, ['llmkit.sh', 'www.llmkit.sh']);
+
+for (const [source, destination] of [
+  ['http://llmkit.sh/', 'https://llmkit.sh/'],
+  ['http://www.llmkit.sh/docs?provider=openai', 'https://www.llmkit.sh/docs?provider=openai'],
+  ['http://llmkit.sh:8080/pricing', 'https://llmkit.sh/pricing'],
+]) {
+  assert.equal(getHttpsRedirectUrl(new URL(source)), destination, source);
+}
+
+for (const source of [
+  'https://llmkit.sh/',
+  'https://www.llmkit.sh/docs',
+  'http://api.llmkit.sh/health',
+  'http://llmkit.sh.example.com/',
+  'http://llmkit-web-staging.workers.dev/',
+]) {
+  assert.equal(getHttpsRedirectUrl(new URL(source)), null, source);
+}
 
 const wrangler = JSON.parse(readFileSync(`${packageRoot}/wrangler.jsonc`, 'utf8'));
 assert.equal(wrangler.name, 'llmkit-web');
@@ -57,8 +78,12 @@ assert.doesNotMatch(deploymentContract, /SUPABASE_SERVICE_KEY|CLERK_SECRET_KEY|A
 
 const worker = readFileSync(`${packageRoot}/cloudflare-worker.ts`, 'utf8');
 assert.doesNotMatch(worker, /@clerk\/nextjs|SUPABASE_SERVICE_KEY/);
+assert.match(worker, /createHttpsRedirectResponse\(requestUrl\)/);
+assert.match(worker, /withHeaders\(httpsRedirectResponse\)/);
 assert.match(worker, /status:\s*503/);
 assert.match(worker, /Retry-After/);
 assert.match(worker, /Content-Security-Policy/);
 
-console.log('RECOVERY_BOUNDARY PASS (blocked tenant surfaces, public routes, isolated staging)');
+console.log(
+  'RECOVERY_BOUNDARY PASS (HTTPS redirect, blocked tenant surfaces, public routes, isolated staging)',
+);

--- a/scripts/run-js-tests.mjs
+++ b/scripts/run-js-tests.mjs
@@ -23,6 +23,7 @@ const tests = [
   'packages/proxy/test/log-secret-runtime-proof.mjs',
   'packages/proxy/test/worker-deploy-guard-test.mjs',
   'packages/dashboard/test/recovery-boundary-test.mjs',
+  'packages/dashboard/test/https-redirect-runtime-test.mjs',
   'packages/cli/test/parser-test.mjs',
   'packages/sdk/test/tracker-test.mjs',
   'packages/mcp-server/test/smoke-test.mjs',


### PR DESCRIPTION
## Summary

Redirect plain HTTP requests for `llmkit.sh` and `www.llmkit.sh` to the matching HTTPS URL at the web Worker boundary.

The redirect is intentionally limited to those two hosts. It does not add a zone-wide rule, change `api.llmkit.sh`, capture workers.dev staging, or deploy production.

## What changed

- Added an exact allowlist for the two public web hosts.
- Return a 308 response before public-recovery path classification.
- Preserve the request path and query while canonicalizing HTTPS to port 443.
- Added direct Workerd regression coverage for redirect and non-capture cases.
- Registered the runtime fixture with Knip and the root JavaScript test gate.

## Verification

- `corepack pnpm@9.15.4 quality:pr`
- 26 JavaScript test programs
- 113 Python tests plus four fuzz targets
- 95.20% Python statements and 90.56% branches
- 49 pgTAP assertions and populated migration proof
- Workerd exact-host redirect proof
- Linux OpenNext build
- Wrangler staging dry-run

## Review focus

- Confirm that only root and `www` plain HTTP requests redirect.
- Confirm that API, HTTPS, lookalike, and workers.dev requests remain untouched.
- Confirm that 308 is the intended method-preserving redirect.
- Confirm that the redirect belongs before recovery route classification.

Rendered desktop and mobile production QA remains a post-deploy gate.
