### PR TITLE
Make LLMKit recovery state truthful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ htmlcov/
 .wrangler/
 .dev.vars
 .dev.keys
+packages/dashboard/cloudflare-env.d.ts
 
 # next.js
 .next/

--- a/packages/dashboard/cloudflare-worker.ts
+++ b/packages/dashboard/cloudflare-worker.ts
@@ -4,6 +4,7 @@ import openNextHandler from './.open-next/worker.js';
 import {
   classifyRecoveryPath,
   createHttpsRedirectResponse,
+  getWorkerVersionHeaders,
 } from './src/lib/public-recovery';
 
 const SECURITY_HEADERS = {
@@ -40,10 +41,11 @@ function withHeaders(response: Response, extraHeaders: Record<string, string> = 
 export default {
   async fetch(request: Request, env: unknown, context: unknown): Promise<Response> {
     const requestUrl = new URL(request.url);
+    const versionHeaders = getWorkerVersionHeaders(env);
     const httpsRedirectResponse = createHttpsRedirectResponse(requestUrl);
 
     if (httpsRedirectResponse) {
-      return withHeaders(httpsRedirectResponse);
+      return withHeaders(httpsRedirectResponse, versionHeaders);
     }
 
     const boundary = classifyRecoveryPath(requestUrl.pathname);
@@ -54,7 +56,7 @@ export default {
           { error: 'The authenticated LLMKit surface is being restored.' },
           { status: 503 },
         ),
-        RECOVERY_HEADERS,
+        { ...RECOVERY_HEADERS, ...versionHeaders },
       );
     }
 
@@ -73,9 +75,9 @@ export default {
         headers: recoveryPage.headers,
       });
 
-      return withHeaders(unavailablePage, RECOVERY_HEADERS);
+      return withHeaders(unavailablePage, { ...RECOVERY_HEADERS, ...versionHeaders });
     }
 
-    return withHeaders(await openNextHandler.fetch(request, env, context));
+    return withHeaders(await openNextHandler.fetch(request, env, context), versionHeaders);
   },
 };

--- a/packages/dashboard/src/app/(public)/compare/page.tsx
+++ b/packages/dashboard/src/app/(public)/compare/page.tsx
@@ -2,6 +2,7 @@
 import type { Metadata } from 'next';
 import { PublicFooter } from '@/components/public-footer';
 import { PublicNavStatic } from '@/components/public-nav-static';
+import { RECOVERY_PUBLIC_CTA } from '@/lib/public-recovery';
 import { Calculator } from './calculator';
 
 export const metadata: Metadata = {
@@ -63,8 +64,8 @@ export default async function ComparePage() {
             Budget limits reject requests before they reach the provider.
           </p>
           <div className="mt-4 flex items-center justify-center gap-3">
-            <a href="/sign-up" className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
-              Get started free
+            <a href={RECOVERY_PUBLIC_CTA.href} className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
+              {RECOVERY_PUBLIC_CTA.label}
             </a>
             <a href="/pricing" className="rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-2 text-sm text-zinc-300 hover:bg-white/[0.06] transition">
               Full pricing table

--- a/packages/dashboard/src/app/(public)/docs/page.tsx
+++ b/packages/dashboard/src/app/(public)/docs/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { PublicFooter } from '@/components/public-footer';
 import { PublicNavStatic } from '@/components/public-nav-static';
+import { RECOVERY_STATUS_HREF } from '@/lib/public-recovery';
 
 export const metadata: Metadata = {
   title: 'Getting Started - LLMKit',
@@ -48,7 +49,7 @@ export default function DocsPage() {
       <div className="mx-auto max-w-3xl space-y-16 px-6 pb-16">
 
         {/* MCP Server */}
-        <section>
+        <section id="local-setup" className="scroll-mt-20">
           <div className="mb-2 flex items-center gap-3">
             <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-violet-500/10 font-mono text-sm font-bold text-violet-400">1</span>
             <h2 className="text-lg font-semibold">MCP Server</h2>
@@ -166,29 +167,26 @@ export default function DocsPage() {
           </div>
         </section>
 
-        {/* API Gateway */}
+        {/* Hosted API Gateway */}
         <section>
-          <h2 className="mb-2 text-lg font-semibold">API Gateway (optional)</h2>
+          <h2 className="mb-2 text-lg font-semibold">Hosted API gateway</h2>
           <p className="mb-4 text-sm text-zinc-400">
-            For budget enforcement and centralized logging. Create an account, get an API key, and route requests through the proxy.
+            Hosted account creation and API-key management are temporarily unavailable while the authenticated service is restored.
           </p>
           <div className="space-y-4">
             <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-5">
-              <p className="text-sm font-medium text-zinc-200">1. Create an account</p>
+              <p className="text-sm font-medium text-zinc-200">Available now</p>
               <p className="mt-1 text-xs text-zinc-500">
-                <Link href="/sign-up" className="text-violet-400 hover:text-violet-300 transition">Sign up free</Link> and get an API key from the dashboard.
+                The local SDK, CLI, and MCP paths above remain available without an LLMKit account.
               </p>
             </div>
             <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-5">
-              <p className="text-sm font-medium text-zinc-200">2. Set your provider keys</p>
+              <p className="text-sm font-medium text-zinc-200">Hosted path</p>
               <p className="mt-1 text-xs text-zinc-500">
-                Add your Anthropic, OpenAI, or other provider API keys in Settings. Encrypted with AES-GCM.
-              </p>
-            </div>
-            <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-5">
-              <p className="text-sm font-medium text-zinc-200">3. Configure budgets</p>
-              <p className="mt-1 text-xs text-zinc-500">
-                Set per-key limits (daily, weekly, monthly). Budget enforcement uses a reservation pattern: cost is estimated before the request, rejected if over limit.
+                <Link href={RECOVERY_STATUS_HREF} className="text-violet-400 hover:text-violet-300 transition">
+                  Check the service status
+                </Link>{' '}
+                before attempting dashboard or gateway setup.
               </p>
             </div>
           </div>

--- a/packages/dashboard/src/app/(public)/page.tsx
+++ b/packages/dashboard/src/app/(public)/page.tsx
@@ -6,6 +6,7 @@ import { PublicFooter } from '@/components/public-footer';
 import { PublicNavStatic } from '@/components/public-nav-static';
 import { TerminalDemo } from '@/components/terminal-demo';
 import { TrackClick } from '@/components/track-event';
+import { RECOVERY_PUBLIC_CTA, RECOVERY_STATUS_HREF } from '@/lib/public-recovery';
 
 export const metadata: Metadata = {
   title: 'LLMKit - Know what your AI agents cost',
@@ -32,10 +33,9 @@ const providers = [
 ];
 
 export default function Home() {
-  const ctaHref = '/sign-up';
-  const ctaLabel = 'Get started free';
+  const { href: ctaHref, label: ctaLabel } = RECOVERY_PUBLIC_CTA;
   return (
-    <div className="relative min-h-screen bg-[#0a0a0a] text-white selection:bg-violet-500/30">
+    <div className="relative min-h-screen overflow-x-hidden bg-[#0a0a0a] text-white selection:bg-violet-500/30">
       <div
         className="pointer-events-none fixed inset-0 z-50 opacity-[0.02]"
         style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")` }}
@@ -166,23 +166,23 @@ export default function Home() {
                 Budget enforcement that actually blocks requests. Reservation pattern: estimate before, reject if over, settle after. Per-key and per-session limits.
               </p>
               <p className="mt-4 text-xs text-cyan-400 group-hover:text-cyan-300 transition">
-                Get started {'->'}
+                Set up locally {'->'}
               </p>
             </div>
           </Link>
 
           {/* Dashboard */}
-          <Link href={ctaHref} className="group">
+          <Link href={RECOVERY_STATUS_HREF} className="group">
             <div className="h-full rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 transition hover:border-amber-500/20 hover:bg-white/[0.04]">
               <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10 text-amber-400">
                 <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
               </div>
-              <h3 className="text-base font-semibold">Dashboard</h3>
+              <h3 className="text-base font-semibold">Hosted dashboard</h3>
               <p className="mt-2 text-sm leading-relaxed text-zinc-400">
-                Spend by model, provider, and session. Request log with full cost breakdown. API key management, budget configuration, anomaly detection.
+                Hosted accounts are temporarily unavailable while the authenticated service is restored. Local SDK, CLI, and MCP tools remain available.
               </p>
               <p className="mt-4 text-xs text-amber-400 group-hover:text-amber-300 transition">
-                Try it free {'->'}
+                View service status {'->'}
               </p>
             </div>
           </Link>
@@ -241,13 +241,15 @@ export default function Home() {
 
       {/* cta */}
       <div className="mx-auto max-w-2xl px-6 pb-8 pt-6 text-center">
-        <p className="mb-4 text-sm text-zinc-500">Free while in beta. No credit card.</p>
+        <p className="mb-4 text-sm text-zinc-500">
+          Hosted accounts are temporarily unavailable. Local tools remain available without an account.
+        </p>
         <div className="flex items-center justify-center gap-3">
           <Link
             href={ctaHref}
             className="rounded-lg bg-violet-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-violet-500 transition"
           >
-            Try the dashboard
+            {ctaLabel}
           </Link>
           <TrackClick
             event="cta_click"

--- a/packages/dashboard/src/app/(public)/pricing/page.tsx
+++ b/packages/dashboard/src/app/(public)/pricing/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { PublicFooter } from '@/components/public-footer';
 import { PublicNavStatic } from '@/components/public-nav-static';
 import { TrackClick } from '@/components/track-event';
+import { RECOVERY_PUBLIC_CTA } from '@/lib/public-recovery';
 
 export const metadata: Metadata = {
   title: 'LLM API Pricing Comparison 2026 - 730+ Models, 11 Providers | LLMKit',
@@ -100,8 +101,8 @@ export default async function PricingPage() {
             Budget limits reject requests before they reach the provider.
           </p>
           <div className="mt-4 flex items-center justify-center gap-3">
-            <TrackClick event="cta_click" properties={{ label: "sign_up", location: "pricing" }} href="/sign-up" className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
-              Get started free
+            <TrackClick event="cta_click" properties={{ label: "local_setup", location: "pricing" }} href={RECOVERY_PUBLIC_CTA.href} className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
+              {RECOVERY_PUBLIC_CTA.label}
             </TrackClick>
             <TrackClick event="cta_click" properties={{ label: "view_source", location: "pricing" }} href="https://github.com/smigolsmigol/llmkit" className="rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-2 text-sm text-zinc-300 hover:bg-white/[0.06] transition" target="_blank" rel="noopener noreferrer">
               View source

--- a/packages/dashboard/src/app/(public)/providers/[name]/page.tsx
+++ b/packages/dashboard/src/app/(public)/providers/[name]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { PublicFooter } from '@/components/public-footer';
 import { PublicNavStatic } from '@/components/public-nav-static';
+import { RECOVERY_PUBLIC_CTA } from '@/lib/public-recovery';
 
 const PROVIDERS = [
   'openai', 'anthropic', 'gemini', 'xai', 'groq', 'together',
@@ -188,9 +189,9 @@ export default async function ProviderPage({ params }: { params: Promise<{ name:
             and session attribution. Set budget limits that actually reject requests before they hit the provider.
           </p>
           <div className="mt-4 flex items-center justify-center gap-3">
-            <a href="/sign-up" className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
-              Get started free
-            </a>
+            <Link href={RECOVERY_PUBLIC_CTA.href} className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 transition">
+              {RECOVERY_PUBLIC_CTA.label}
+            </Link>
             <a href="https://github.com/smigolsmigol/llmkit" className="rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-2 text-sm text-zinc-300 hover:bg-white/[0.06] transition" target="_blank" rel="noopener noreferrer">
               View source
             </a>

--- a/packages/dashboard/src/components/public-nav-static.tsx
+++ b/packages/dashboard/src/components/public-nav-static.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { RECOVERY_PUBLIC_CTA } from '@/lib/public-recovery';
 import { AnimatedLogo } from './animated-logo';
 
 const links = [
@@ -38,14 +39,11 @@ export function PublicNavStatic() {
             <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
             <span className="hidden sm:inline">GitHub</span>
           </a>
-          <Link href="/sign-in" className="text-sm text-zinc-400 hover:text-white transition">
-            Sign in
-          </Link>
           <Link
-            href="/sign-up"
+            href={RECOVERY_PUBLIC_CTA.href}
             className="rounded-lg bg-white px-4 py-1.5 text-sm font-medium text-black hover:bg-zinc-200 transition"
           >
-            Get started
+            {RECOVERY_PUBLIC_CTA.label}
           </Link>
           {/* mobile hamburger */}
           <button

--- a/packages/dashboard/src/lib/public-recovery.ts
+++ b/packages/dashboard/src/lib/public-recovery.ts
@@ -12,7 +12,30 @@ export const RECOVERY_BLOCKED_API_PREFIXES = [
 
 export const RECOVERY_WEB_HOSTS = ['llmkit.sh', 'www.llmkit.sh'] as const;
 
+export const RECOVERY_PUBLIC_CTA = {
+  href: '/docs#local-setup',
+  label: 'Use locally',
+} as const;
+
+export const RECOVERY_STATUS_HREF = '/service-restoring';
+
 export type RecoveryBoundary = 'public' | 'blocked-ui' | 'blocked-api';
+
+export function getWorkerVersionHeaders(environment: unknown): Record<string, string> {
+  if (!environment || typeof environment !== 'object') {
+    return {};
+  }
+
+  const metadata = Reflect.get(environment, 'CF_VERSION_METADATA');
+  if (!metadata || typeof metadata !== 'object') {
+    return {};
+  }
+
+  const versionId = Reflect.get(metadata, 'id');
+  return typeof versionId === 'string' && versionId.length > 0
+    ? { 'X-LLMKit-Worker-Version': versionId }
+    : {};
+}
 
 export function getHttpsRedirectUrl(requestUrl: URL): string | null {
   if (

--- a/packages/dashboard/test/recovery-boundary-test.mjs
+++ b/packages/dashboard/test/recovery-boundary-test.mjs
@@ -4,9 +4,12 @@ import { fileURLToPath } from 'node:url';
 import { bucketByHour } from '../src/components/charts/types.ts';
 import {
   classifyRecoveryPath,
+  getWorkerVersionHeaders,
   getHttpsRedirectUrl,
   RECOVERY_BLOCKED_API_PREFIXES,
   RECOVERY_BLOCKED_UI_PREFIXES,
+  RECOVERY_PUBLIC_CTA,
+  RECOVERY_STATUS_HREF,
   RECOVERY_WEB_HOSTS,
 } from '../src/lib/public-recovery.ts';
 
@@ -39,6 +42,15 @@ assert.deepEqual(RECOVERY_BLOCKED_API_PREFIXES, [
   '/api/pricing',
 ]);
 assert.deepEqual(RECOVERY_WEB_HOSTS, ['llmkit.sh', 'www.llmkit.sh']);
+assert.deepEqual(RECOVERY_PUBLIC_CTA, { href: '/docs#local-setup', label: 'Use locally' });
+assert.equal(RECOVERY_STATUS_HREF, '/service-restoring');
+
+assert.deepEqual(
+  getWorkerVersionHeaders({ CF_VERSION_METADATA: { id: 'worker-version-123' } }),
+  { 'X-LLMKit-Worker-Version': 'worker-version-123' },
+);
+assert.deepEqual(getWorkerVersionHeaders({ CF_VERSION_METADATA: { id: '' } }), {});
+assert.deepEqual(getWorkerVersionHeaders({}), {});
 
 for (const [source, destination] of [
   ['http://llmkit.sh/', 'https://llmkit.sh/'],
@@ -73,6 +85,26 @@ assert.deepEqual(
 assert.equal(wrangler.env.staging.workers_dev, true);
 assert.equal(wrangler.env.staging.preview_urls, true);
 assert.deepEqual(wrangler.env.staging.routes, []);
+assert.equal(wrangler.version_metadata.binding, 'CF_VERSION_METADATA');
+assert.equal(wrangler.env.staging.version_metadata.binding, 'CF_VERSION_METADATA');
+
+for (const relativePath of [
+  'src/components/public-nav-static.tsx',
+  'src/app/(public)/page.tsx',
+  'src/app/(public)/docs/page.tsx',
+  'src/app/(public)/compare/page.tsx',
+  'src/app/(public)/pricing/page.tsx',
+  'src/app/(public)/providers/[name]/page.tsx',
+]) {
+  const source = readFileSync(`${packageRoot}/${relativePath}`, 'utf8');
+  assert.doesNotMatch(source, /\/sign-(?:in|up)/, relativePath);
+}
+
+const docsSource = readFileSync(`${packageRoot}/src/app/(public)/docs/page.tsx`, 'utf8');
+assert.ok(
+  docsSource.indexOf('id="local-setup"') < docsSource.indexOf('Hosted API gateway'),
+  'the local setup anchor must precede the hosted recovery notice',
+);
 
 const [costBucket] = bucketByHour([
   {
@@ -118,10 +150,11 @@ assert.doesNotMatch(deploymentContract, /SUPABASE_SERVICE_KEY|CLERK_SECRET_KEY|A
 const worker = readFileSync(`${packageRoot}/cloudflare-worker.ts`, 'utf8');
 assert.doesNotMatch(worker, /@clerk\/nextjs|SUPABASE_SERVICE_KEY/);
 assert.match(worker, /createHttpsRedirectResponse\(requestUrl\)/);
-assert.match(worker, /withHeaders\(httpsRedirectResponse\)/);
+assert.match(worker, /withHeaders\(httpsRedirectResponse, versionHeaders\)/);
 assert.match(worker, /status:\s*503/);
 assert.match(worker, /Retry-After/);
 assert.match(worker, /Content-Security-Policy/);
+assert.match(worker, /getWorkerVersionHeaders\(env\)/);
 
 console.log(
   'RECOVERY_BOUNDARY PASS (HTTPS redirect, blocked tenant surfaces, public routes, isolated staging)',

--- a/packages/dashboard/wrangler.jsonc
+++ b/packages/dashboard/wrangler.jsonc
@@ -16,6 +16,9 @@
   "observability": {
     "enabled": true
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
   "routes": [
     {
       "pattern": "llmkit.sh",
@@ -48,6 +51,9 @@
       ],
       "vars": {
         "LLMKIT_DEPLOYMENT_MODE": "public-recovery"
+      },
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
       }
     }
   }


### PR DESCRIPTION
## Summary

Stop the public site from advertising hosted signup while the authenticated service is intentionally unavailable.

## What changed

- Route public calls to action to the local setup path instead of blocked auth routes.
- Explain the hosted recovery boundary on the homepage and docs.
- Expose the Cloudflare Worker version ID on every response for deployment verification.
- Cover production and staging metadata bindings and reject stale signup links in regression tests.
- Remove mobile horizontal overflow from the public homepage.

## Verification

- Dashboard recovery contract: passed.
- Dashboard typecheck: passed.
- Next production build: passed.
- Wrangler binding generation: passed.
- Desktop and 375 px mobile browser checks: passed.
- Semgrep: 0 findings across 335 files.
- Full local PR gate reached one unrelated Windows-only frozen latency failure: 39 ms median / 81 ms p95; the isolated rerun was 47 ms / 68 ms. Branch CI remains the merge gate.
- OpenNext Cloudflare dry-run reached the known Windows symlink boundary after validating the Wrangler configuration.

## Review focus

Confirm that no public route promises hosted signup during recovery, local setup remains discoverable, and every Worker response carries an opaque deployment version identifier.

No production deployment or package release is included.