### PR TITLE
Harden release and hosted truth gates

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -49,6 +49,22 @@ jobs:
             fi
           }
 
+          check_http_contains() {
+            local name="$1" url="$2" expected="$3"
+            local response status body
+            response=$(curl -sSL -w '\n%{http_code}' \
+              --max-time 15 --retry 2 --retry-all-errors "$url" || true)
+            status="${response##*$'\n'}"
+            body="${response%$'\n'*}"
+            if [ "$status" = "000" ] || [ -z "$status" ]; then
+              record_failure "${name}: connection failed"
+            elif [ "$status" != "200" ]; then
+              record_failure "${name}: got ${status}, expected 200"
+            elif ! printf '%s' "$body" | grep -Fq "$expected"; then
+              record_failure "${name}: missing expected recovery marker"
+            fi
+          }
+
           check_port() {
             local name="$1" host="$2" port="$3"
             local status
@@ -93,7 +109,13 @@ jobs:
           # Parked or private runtime surfaces are checked only on an explicit manual run.
           if [ "$CHECK_RUNTIME" = "true" ]; then
             check_http "Proxy" "https://api.llmkit.sh/health"
-            check_http "Dashboard" "https://llmkit-dashboard.vercel.app/sign-in"
+            check_http_contains "Dashboard recovery" \
+              "https://llmkit.sh/service-restoring" "Controlled restoration"
+            check_http_contains "Homepage recovery disclosure" \
+              "https://llmkit.sh/" "Hosted accounts are temporarily unavailable"
+            check_http_contains "Docs recovery disclosure" \
+              "https://llmkit.sh/docs" \
+              "Hosted account creation and API-key management are temporarily unavailable"
             if [ -n "$HETZNER_IP" ]; then
               check_port "Analytics API" "$HETZNER_IP" 3200
             fi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,11 @@ name: Publish Python SDK
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: 'Full commit SHA this publication is authorized to release'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +23,12 @@ jobs:
         working-directory: packages/python-sdk
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: verify expected commit
+        run: >-
+          node ../../scripts/assert-unpublished-version.mjs expected-sha
+          "${{ inputs.expected_sha }}"
+          "${{ github.sha }}"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
           - cli
           - mcp-server
           - ai-sdk-provider
+      expected_sha:
+        description: 'Full commit SHA this publication is authorized to release'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -25,6 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: verify expected commit
+        run: >-
+          node scripts/assert-unpublished-version.mjs expected-sha
+          "${{ inputs.expected_sha }}"
+          "${{ github.sha }}"
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
@@ -79,6 +89,7 @@ jobs:
           pnpm exec publint /tmp/pkg-check/package
           node --input-type=module <<'NODE'
           import { readFile } from 'node:fs/promises';
+          import { assertPublishedVersion } from './scripts/assert-unpublished-version.mjs';
 
           const packed = JSON.parse(await readFile('/tmp/pkg-check/package/package.json', 'utf8'));
           if (packed.name !== process.env.PACKAGE_NAME) {
@@ -98,6 +109,7 @@ jobs:
             if (shared !== expected) {
               throw new Error(`Packed shared dependency mismatch: ${shared} != ${expected}`);
             }
+            await assertPublishedVersion('npm', '@f3d1/llmkit-shared', expected);
           }
           NODE
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,9 +1,8 @@
 # Quickstart
 
-Get AI cost tracking running in under 5 minutes.
+Start with a local path below. The CLI and local Python transport need no LLMKit account.
 
-**Prerequisites:** Create a free account at [llmkit.sh](https://llmkit.sh)
-and grab an API key from the Keys tab. Add your provider key (OpenAI, Anthropic, etc.) in the Providers tab.
+Gateway examples require an existing LLMKit API key. Account creation and key management are temporarily unavailable while the authenticated service is restored.
 
 ---
 
@@ -87,7 +86,7 @@ const { text } = await generateText({
 pip install llmkit-sdk
 ```
 
-**With the proxy** (budget enforcement, logging, dashboard):
+**With the proxy** (budget enforcement and logging, requires an existing LLMKit API key):
 
 ```python
 from openai import OpenAI
@@ -123,7 +122,7 @@ that accepts `http_client` (OpenAI, Anthropic, Mistral, etc.).
 
 ---
 
-## Direct API (curl)
+## Direct API (curl, existing key)
 
 No SDK needed. Point any HTTP client at the proxy.
 
@@ -142,10 +141,11 @@ Cost comes back in the `x-llmkit-cost` response header.
 
 ---
 
-## What's next
+## Gateway follow-up
 
-- Open [llmkit.sh](https://llmkit.sh) to see your costs, requests, and sessions
-- Set a budget in the dashboard to cap spend per key or per session
+- Local CLI and Python tracking above are available without an LLMKit account
+- Existing-key gateway users can query spend and budgets through the MCP proxy tools
+- New account creation and dashboard key or budget management remain temporarily unavailable while the authenticated service is restored
 - Add `x-llmkit-session-id` headers to group requests by agent run
 - Add `x-llmkit-user-id` headers to track costs per end-user
 - Set up the [MCP server](packages/mcp-server) to query costs from Claude Code, Cline, or Cursor

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ npx @f3d1/llmkit-cli -- python my_agent.py
 
 Use `-v` for per-request output or `--json` for machine-readable results.
 
-### Gateway mode
+### Gateway mode (existing key)
 
-Create a key at [llmkit.sh](https://llmkit.sh), then point an OpenAI-compatible client at the gateway:
+Gateway examples require an existing LLMKit API key. Account creation and key management are temporarily unavailable while the authenticated service is restored. Use the local tracking paths above if you do not already have a key.
 
 ```python
 from openai import OpenAI

--- a/scripts/assert-unpublished-version.mjs
+++ b/scripts/assert-unpublished-version.mjs
@@ -30,8 +30,40 @@ export async function assertUnpublishedVersion(registry, name, version, fetchImp
   throw new Error(`Could not verify ${name}@${version} on ${registry}: HTTP ${response.status}.`);
 }
 
+export async function assertPublishedVersion(registry, name, version, fetchImpl = fetch) {
+  const url = registryVersionUrl(registry, name, version);
+  const response = await fetchImpl(url, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (response.ok) return url;
+  throw new Error(`${name}@${version} is not available on ${registry}: HTTP ${response.status}.`);
+}
+
+export function assertExpectedSha(expectedSha, actualSha) {
+  if (!/^[0-9a-f]{40}$/i.test(expectedSha)) {
+    throw new Error('Expected SHA must be a full 40-character commit SHA.');
+  }
+  if (expectedSha !== actualSha) {
+    throw new Error(`Expected SHA ${expectedSha} does not match checked-out SHA ${actualSha}.`);
+  }
+  return actualSha;
+}
+
 async function main() {
-  const [registry, name, version] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  if (args[0] === 'expected-sha') {
+    const [, expectedSha, actualSha] = args;
+    if (!expectedSha || !actualSha) {
+      throw new Error('Usage: node scripts/assert-unpublished-version.mjs expected-sha <expected> <actual>');
+    }
+    assertExpectedSha(expectedSha, actualSha);
+    console.log(`EXPECTED_SHA PASS ${actualSha}`);
+    return;
+  }
+
+  const [registry, name, version] = args;
   if (!registry || !name || !version) {
     throw new Error('Usage: node scripts/assert-unpublished-version.mjs <npm|pypi> <name> <version>');
   }

--- a/test/health-check-workflow-test.mjs
+++ b/test/health-check-workflow-test.mjs
@@ -17,6 +17,11 @@ const runtimeTruthCalls = [
     pattern: /check_http_contains "Docs recovery disclosure"\s+\\\s+"https:\/\/llmkit\.sh\/docs"\s+\\\s+"Hosted account creation and API-key management are temporarily unavailable"/,
     violation: '"Hosted account creation and API-key management are temporarily unavailable"',
   },
+  {
+    label: 'dashboard recovery',
+    pattern: /check_http_contains "Dashboard recovery"\s+\\\s+"https:\/\/llmkit\.sh\/service-restoring" "Controlled restoration"/,
+    violation: '"Controlled restoration"',
+  },
 ];
 
 function assertRuntimeTruthContract(contents) {
@@ -65,11 +70,6 @@ for (const call of runtimeTruthCalls) {
 assert(
   workflow.includes('check_http_contains()') && workflow.includes('grep -Fq "$expected"'),
   'dashboard recovery must verify both a successful response and its recovery marker',
-);
-assert(
-  workflow.includes('https://llmkit.sh/service-restoring') &&
-    workflow.includes('"Controlled restoration"'),
-  'dashboard recovery must check the canonical public recovery page',
 );
 assert(
   !workflow.includes('llmkit-dashboard.vercel.app'),

--- a/test/health-check-workflow-test.mjs
+++ b/test/health-check-workflow-test.mjs
@@ -6,6 +6,33 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
+const runtimeTruthCalls = [
+  {
+    label: 'homepage',
+    pattern: /check_http_contains "Homepage recovery disclosure"\s+\\\s+"https:\/\/llmkit\.sh\/" "Hosted accounts are temporarily unavailable"/,
+    violation: '"Hosted accounts are temporarily unavailable"',
+  },
+  {
+    label: 'docs',
+    pattern: /check_http_contains "Docs recovery disclosure"\s+\\\s+"https:\/\/llmkit\.sh\/docs"\s+\\\s+"Hosted account creation and API-key management are temporarily unavailable"/,
+    violation: '"Hosted account creation and API-key management are temporarily unavailable"',
+  },
+];
+
+function assertRuntimeTruthContract(contents) {
+  const gate = contents.indexOf('if [ "$CHECK_RUNTIME" = "true" ]; then');
+  const gateEnd = contents.indexOf('\n          else', gate);
+  assert(gate >= 0, 'runtime checks need a manual-only gate');
+  assert(gateEnd > gate, 'runtime checks need a bounded manual-only block');
+  const runtimeBlock = contents.slice(gate, gateEnd);
+  for (const call of runtimeTruthCalls) {
+    assert(
+      call.pattern.test(runtimeBlock),
+      `manual runtime truth contract is missing or misbound: ${call.label}`,
+    );
+  }
+}
+
 assert(
   workflow.includes("cron: '17 6 * * *'"),
   'published artifact checks must run once daily',
@@ -18,13 +45,36 @@ assert(
 
 const runtimeGate = workflow.indexOf('if [ "$CHECK_RUNTIME" = "true" ]; then');
 const proxyCheck = workflow.indexOf('check_http "Proxy"');
-const dashboardCheck = workflow.indexOf('check_http "Dashboard"');
+const recoveryCheck = workflow.indexOf('check_http_contains "Dashboard recovery"');
 const publicCheck = workflow.indexOf('check_npm "@f3d1/llmkit-sdk"');
 
 assert(runtimeGate >= 0, 'runtime checks need a manual-only gate');
 assert(publicCheck >= 0 && publicCheck < runtimeGate, 'published artifacts must remain scheduled');
 assert(proxyCheck > runtimeGate, 'proxy health must be inside the runtime gate');
-assert(dashboardCheck > runtimeGate, 'dashboard health must be inside the runtime gate');
+assert(recoveryCheck > runtimeGate, 'dashboard recovery health must be inside the runtime gate');
+assertRuntimeTruthContract(workflow);
+for (const call of runtimeTruthCalls) {
+  let violationBlocked = false;
+  try {
+    assertRuntimeTruthContract(workflow.replace(call.violation, ''));
+  } catch {
+    violationBlocked = true;
+  }
+  assert(violationBlocked, `runtime truth violation was accepted: ${call.label}`);
+}
+assert(
+  workflow.includes('check_http_contains()') && workflow.includes('grep -Fq "$expected"'),
+  'dashboard recovery must verify both a successful response and its recovery marker',
+);
+assert(
+  workflow.includes('https://llmkit.sh/service-restoring') &&
+    workflow.includes('"Controlled restoration"'),
+  'dashboard recovery must check the canonical public recovery page',
+);
+assert(
+  !workflow.includes('llmkit-dashboard.vercel.app'),
+  'the disabled legacy dashboard must not be used as a health surface',
+);
 
 assert(workflow.includes('concurrency:'), 'overlapping health runs must be collapsed');
 assert(workflow.includes('timeout-minutes: 10'), 'the health job needs a bounded runtime');

--- a/test/release-workflow-contract-test.mjs
+++ b/test/release-workflow-contract-test.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import {
+  assertExpectedSha,
+  assertPublishedVersion,
   assertUnpublishedVersion,
   registryVersionUrl,
 } from '../scripts/assert-unpublished-version.mjs';
@@ -11,6 +13,10 @@ const pypiWorkflow = await readFile('.github/workflows/publish-pypi.yml', 'utf8'
 
 assert.match(npmWorkflow, /github\.ref == 'refs\/heads\/main'/);
 assert.match(pypiWorkflow, /github\.ref == 'refs\/heads\/main'/);
+assert.match(npmWorkflow, /expected_sha:/);
+assert.match(pypiWorkflow, /expected_sha:/);
+assert.match(npmWorkflow, /expected-sha[\s\S]*\$\{\{ github\.sha \}\}/);
+assert.match(pypiWorkflow, /expected-sha[\s\S]*\$\{\{ github\.sha \}\}/);
 assert.match(npmWorkflow, /assert-unpublished-version\.mjs npm/);
 assert.match(pypiWorkflow, /assert-unpublished-version\.mjs pypi/);
 assert.match(npmWorkflow, /pnpm exec publint \/tmp\/pkg-check\/package/);
@@ -18,6 +24,16 @@ assert.match(npmWorkflow, /tar -xzf \/tmp\/pkg\/\*\.tgz -C \/tmp\/pkg-check/);
 assert.match(npmWorkflow, /source\.dependencies\?\.\['@f3d1\/llmkit-shared'\]/);
 assert.match(npmWorkflow, /packed\.dependencies\?\.\['@f3d1\/llmkit-shared'\]/);
 assert.match(npmWorkflow, /if \(sourceShared\)/);
+
+const verifyPackedStart = npmWorkflow.indexOf('      - name: verify packed artifact');
+const verifyPackedEnd = npmWorkflow.indexOf('\n      - name:', verifyPackedStart + 1);
+assert(verifyPackedStart >= 0 && verifyPackedEnd > verifyPackedStart, 'verify packed artifact step must exist');
+const verifyPackedStep = npmWorkflow.slice(verifyPackedStart, verifyPackedEnd);
+assert.match(
+  verifyPackedStep,
+  /import \{ assertPublishedVersion \} from '\.\/scripts\/assert-unpublished-version\.mjs';/,
+);
+assert.match(verifyPackedStep, /await assertPublishedVersion\('npm', '@f3d1\/llmkit-shared', expected\)/);
 assert.doesNotMatch(npmWorkflow, /publint[^\n]*--pack=npm/);
 assert.match(pypiWorkflow, /python -m pytest/);
 assert.match(pypiWorkflow, /python -m pip install --force-reinstall --no-deps dist\/\*\.whl/);
@@ -48,6 +64,23 @@ await assert.rejects(
 await assert.rejects(
   assertUnpublishedVersion('pypi', 'llmkit-sdk', '0.1.10', async () => ({ status: 503, ok: false })),
   /Could not verify/,
+);
+
+await assertPublishedVersion('npm', '@f3d1/llmkit-shared', '0.0.7', async () => ({ status: 200, ok: true }));
+await assert.rejects(
+  assertPublishedVersion('npm', '@f3d1/llmkit-shared', '0.0.7', async () => ({ status: 404, ok: false })),
+  /not available/,
+);
+
+const sha = '5caac332faaf1938ff144594760dd9958fafeb91';
+assert.equal(assertExpectedSha(sha, sha), sha);
+assert.throws(
+  () => assertExpectedSha(sha, 'ddd3f5034002fcd2d326640cb00b791f26a96494'),
+  /does not match/,
+);
+assert.throws(
+  () => assertExpectedSha('not-a-sha', sha),
+  /full 40-character/,
 );
 
 console.log('RELEASE_WORKFLOW_CONTRACT PASS');


### PR DESCRIPTION
## Summary

Make package publication fail closed on the reviewed main commit and keep public recovery claims aligned with the hosted product state.

## What changed

- Require the expected main SHA in the manual npm and PyPI workflows.
- Refuse SDK and CLI publication until the matching shared package version exists.
- Validate unpublished versions and packed dependency metadata before publication.
- Remove unavailable hosted sign-up and API-key acquisition instructions from public docs.
- Verify homepage and docs recovery disclosures in the manual runtime health check without adding scheduled probes.

## Verification

- Full pnpm quality:pr gate passed.
- Release workflow contract tests passed.
- Health-check workflow contract tests passed, including marker-removal violations.
- Workflow YAML parsing and git diff --check passed.
- Linux OpenNext staging dry-run completed successfully.

## Review focus

Confirm that manual publication stays main and SHA gated, SDK and CLI preserve shared-first release ordering, and scheduled health checks do not execute the new hosted runtime probes.

## Deployment

This PR does not deploy or publish packages. The hosted disclosures and package versions remain unchanged until their separate post-merge workflows run.