### PR TITLE
Repair Python release floor test

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -49,6 +49,8 @@ jobs:
           node ../../scripts/assert-unpublished-version.mjs pypi llmkit-sdk "$VERSION"
 
       - name: test declared Python floor
+        env:
+          PYTHONPATH: src
         run: python -m pytest
 
       - name: build

--- a/test/release-workflow-contract-test.mjs
+++ b/test/release-workflow-contract-test.mjs
@@ -35,7 +35,11 @@ assert.match(
 );
 assert.match(verifyPackedStep, /await assertPublishedVersion\('npm', '@f3d1\/llmkit-shared', expected\)/);
 assert.doesNotMatch(npmWorkflow, /publint[^\n]*--pack=npm/);
-assert.match(pypiWorkflow, /python -m pytest/);
+const pythonFloorStart = pypiWorkflow.indexOf('      - name: test declared Python floor');
+const pythonFloorEnd = pypiWorkflow.indexOf('\n      - name:', pythonFloorStart + 1);
+assert(pythonFloorStart >= 0 && pythonFloorEnd > pythonFloorStart, 'Python floor step must exist');
+const pythonFloorStep = pypiWorkflow.slice(pythonFloorStart, pythonFloorEnd);
+assert.match(pythonFloorStep, /env:\n\s+PYTHONPATH: src\n\s+run: python -m pytest/);
 assert.match(pypiWorkflow, /python -m pip install --force-reinstall --no-deps dist\/\*\.whl/);
 assert.match(pypiWorkflow, /packages-dir: packages\/python-sdk\/dist\//);
 


### PR DESCRIPTION
﻿## Summary

The Python release workflow stopped before build because its source-layout package was not on the import path during the Python 3.11 floor test.

## What changed

- Bind `PYTHONPATH=src` only to the publish workflow's floor-test step.
- Make the release contract extract that exact step and require the import-path binding beside `python -m pytest`.
- Leave package bytes, versioning, attestation, trusted publishing, and registry guards unchanged.

## Verification

- Release workflow contract: passed.
- Workflow YAML parse and diff checks: passed.
- Linux Python 3.11 source-layout test: 113 passed.
- Commit hooks, including actionlint and secret scanning: passed.

## Review focus

Confirm the change only repairs source discovery for the pre-build floor test and does not weaken artifact or publication gates.
