### PR TITLE
Use npm OIDC for package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,8 +120,6 @@ jobs:
 
       - name: publish with provenance
         run: npm publish /tmp/pkg/*.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: alert on failure
         if: failure()

--- a/test/release-workflow-contract-test.mjs
+++ b/test/release-workflow-contract-test.mjs
@@ -19,6 +19,8 @@ assert.match(npmWorkflow, /expected-sha[\s\S]*\$\{\{ github\.sha \}\}/);
 assert.match(pypiWorkflow, /expected-sha[\s\S]*\$\{\{ github\.sha \}\}/);
 assert.match(npmWorkflow, /assert-unpublished-version\.mjs npm/);
 assert.match(pypiWorkflow, /assert-unpublished-version\.mjs pypi/);
+assert.match(npmWorkflow, /id-token: write/);
+assert.doesNotMatch(npmWorkflow, /NODE_AUTH_TOKEN|secrets\.NPM_TOKEN/);
 assert.match(npmWorkflow, /pnpm exec publint \/tmp\/pkg-check\/package/);
 assert.match(npmWorkflow, /tar -xzf \/tmp\/pkg\/\*\.tgz -C \/tmp\/pkg-check/);
 assert.match(npmWorkflow, /source\.dependencies\?\.\['@f3d1\/llmkit-shared'\]/);
@@ -50,6 +52,13 @@ const publishAt = npmWorkflow.indexOf('npm publish /tmp/pkg/*.tgz');
 assert(packAt >= 0 && packAt < verifyAt, 'artifact verification must follow the canonical pack');
 assert(verifyAt < attestAt, 'the verified artifact must be attested');
 assert(attestAt < publishAt, 'the attested artifact must be published');
+
+const publishStepStart = npmWorkflow.indexOf('      - name: publish with provenance');
+const publishStepEnd = npmWorkflow.indexOf('\n      - name:', publishStepStart + 1);
+assert(publishStepStart >= 0 && publishStepEnd > publishStepStart, 'publish step must exist');
+const publishStep = npmWorkflow.slice(publishStepStart, publishStepEnd);
+assert.match(publishStep, /npm publish \/tmp\/pkg\/\*\.tgz --provenance --access public/);
+assert.doesNotMatch(publishStep, /env:|NODE_AUTH_TOKEN|NPM_TOKEN/);
 
 assert.equal(
   registryVersionUrl('npm', '@f3d1/llmkit-sdk', '0.0.8'),


### PR DESCRIPTION
## Summary

Use npm trusted publishing for package releases instead of a long-lived repository token.

## What changed

- Remove `NODE_AUTH_TOKEN` from the npm publish step so npm can consume GitHub's OIDC identity token.
- Add a workflow contract that rejects any return of `NPM_TOKEN` or step-level token injection.
- Preserve the existing exact-SHA, unpublished-version, pack, dependency-order, attestation, and provenance gates.

## Verification

- `corepack pnpm@9.15.4 quality:pr`
- `node test/release-workflow-contract-test.mjs`
- Workflow YAML parse
- `git diff --check`

## Review focus

Confirm that the publish step has no token environment while retaining `id-token: write` and `npm publish --provenance`.