### PR TITLE
Fix isolated staging deployment preflight

### DIFF
--- a/STAGING_PROOF.md
+++ b/STAGING_PROOF.md
@@ -50,17 +50,33 @@ node node_modules/supabase/dist/supabase.js migration list --linked
 node node_modules/supabase/dist/supabase.js db push --linked --dry-run
 ```
 
-Stop unless the pending set matches the repository migration set. Applying migrations is a separate database mutation decision.
+Supabase data-less branches created from an unversioned production project may contain one synthetic
+`remote_schema` migration. That record is a branch bootstrap marker, not proof that the repository
+migrations ran. For a disposable branch only:
+
+1. Generate `db diff --from migrations --to linked --schema public` and retain the output as the
+   pre-migration drift observation.
+2. Mark the synthetic `remote_schema` version reverted and the repository baseline version applied.
+3. Repeat the dry-run. It must name exactly the remaining repository migrations. The first pending
+   migration contains a fail-closed baseline preflight; do not bypass it if it rejects the inherited
+   schema.
+
+Do not repair migration history on production. Applying migrations remains a separate database
+mutation decision.
 
 After approval:
 
 ```powershell
 node node_modules/supabase/dist/supabase.js db push --linked
-node node_modules/supabase/dist/supabase.js test db --linked supabase/tests/database
 node node_modules/supabase/dist/supabase.js db lint --linked --schema public --level warning --fail-on warning
 node node_modules/supabase/dist/supabase.js migration list --linked
+node node_modules/supabase/dist/supabase.js db diff --from migrations --to linked --schema public
 node node_modules/supabase/dist/supabase.js unlink
 ```
+
+The final schema diff must be empty. SQL pgTAP tests remain a local/CI gate because hosted branch
+login roles may not be allowed to execute the `extensions.plan` helper. The hosted proof below is
+the branch's real-consumer gate; a remote pgTAP permission error is `NOT RUN`, never a pass.
 
 ## Guarded deployment
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "kguard": "^0.1.0",
     "knip": "^5.85.0",
     "publint": "^0.3.23",
-    "supabase": "2.112.0",
+    "supabase": "2.113.0",
     "turbo": "^2.10.8",
     "typescript": "^5.7.0"
   }

--- a/packages/proxy/test/worker-deploy-guard-test.mjs
+++ b/packages/proxy/test/worker-deploy-guard-test.mjs
@@ -93,6 +93,10 @@ assert(
   'Deploy guard does not bind staging to the source commit.',
 );
 assert(
+  !readFileSync(deployScript, 'utf8').includes("'--yes'"),
+  'Deploy guard passes the removed --yes option to Wrangler.',
+);
+assert(
   readFileSync(deployScript, 'utf8').includes("'--format',\n      'json'")
     && readFileSync(deployScript, 'utf8').includes("'--secrets-file'")
     && readFileSync(deployScript, 'utf8').includes("'--account-id'")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^0.3.23
         version: 0.3.23
       supabase:
-        specifier: 2.112.0
-        version: 2.112.0
+        specifier: 2.113.0
+        version: 2.113.0
       turbo:
         specifier: ^2.10.8
         version: 2.10.8
@@ -1691,43 +1691,43 @@ packages:
     resolution: {integrity: sha512-l1InCp4j98d09LZ6+RgubgF4eVPGBGXcLEhFusLg1qUCHJ2IEkYu5FohKK+eaFmIOwEk0kqG/j/lycw5e15mcQ==}
     engines: {node: '>=22.0.0'}
 
-  '@supabase/cli-darwin-arm64@2.112.0':
-    resolution: {integrity: sha512-XmhTrdorWw7waVN1v1CBHhP562fZtQoR6cga3saHO5D4gJO75eEDs/cv56PdDZk4mYNey0xi3QbTijH2UcdjJg==}
+  '@supabase/cli-darwin-arm64@2.113.0':
+    resolution: {integrity: sha512-Q400lezZrzYf7+LSJBNHCUeggM4NB+JOZr/RzyH9+H3TKrLCM5h9uWoU3fkEuVcchBArmYYRXBWqsCwq3DWdzg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@supabase/cli-darwin-x64@2.112.0':
-    resolution: {integrity: sha512-LH37QH8Pcle8CN2MP9170HswpQ1nzmhdNUScs3Xx53YehhSB3sQSUXjqco2YPHTFkFQAunKv8fGbD1G38w6q8w==}
+  '@supabase/cli-darwin-x64@2.113.0':
+    resolution: {integrity: sha512-0v4d1mRVb5Et4+QjdrZRtHpsO1fRibEUXAij2TNcBuMn4E3SujZBMbMO0WPpOKJEpj6yuZGF+o4T8x6duA1x1Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@supabase/cli-linux-arm64-musl@2.112.0':
-    resolution: {integrity: sha512-L1UiNxRqQ+rXUtWzdfrT2mV1i3lp450P+5qbyA9CrBshUVPUwVX/7WxFr7gG/eQxcbXwPIpIZsC08YBXFYC+dQ==}
+  '@supabase/cli-linux-arm64-musl@2.113.0':
+    resolution: {integrity: sha512-zSsa4cAQV5bAZ8pd+nTvqs+tCusJkZWCkUA8nu+kuCWoJ++wqenkRqu9Y9e9CYu8FXOePBMxpThxc0NcF9BMdw==}
     cpu: [arm64]
     os: [linux]
 
-  '@supabase/cli-linux-arm64@2.112.0':
-    resolution: {integrity: sha512-cNva0gFJhsN1BQ3TR0jCalG0RPhvkDjyoOaYHtyRzGwtSgpJThtgNj04UFOz5O8p9hc2RzuLmvktiwf5N6LGeg==}
+  '@supabase/cli-linux-arm64@2.113.0':
+    resolution: {integrity: sha512-cyNoYTPjqOgb03vo58DwNaB3H9SWI3ea9rKKc411L93oAu2W9tYgLM5Xb2jSW3DTxzGcbWHXwOSSZxgBZCrohA==}
     cpu: [arm64]
     os: [linux]
 
-  '@supabase/cli-linux-x64-musl@2.112.0':
-    resolution: {integrity: sha512-l7+P+ez2OmiaUdTHqlSvX1hpEIZQtYyPNxoYmFknofNQOlsVssd+mfsehYigtTcQrDiP7yi7pSIf6IAVMdiPyA==}
+  '@supabase/cli-linux-x64-musl@2.113.0':
+    resolution: {integrity: sha512-9bo75wjiTVndmBqN6uoxEsmr1AhSfHLLXd1GbzyKA6K8N/H7r1wAeHcWBw95GK98ryGg0gpUXo4omdRUiKljZQ==}
     cpu: [x64]
     os: [linux]
 
-  '@supabase/cli-linux-x64@2.112.0':
-    resolution: {integrity: sha512-mkvOy5dmth4dQoL8XrMpGZJybGDsebbESuaKEFULHrRDgg0BuS5OZ5yKDJ3lOl6Ng2uSBpuy02UhdudiHVZAoA==}
+  '@supabase/cli-linux-x64@2.113.0':
+    resolution: {integrity: sha512-cG04d9QgSA4n0etvPbZmAKODdkhF40rBZriLWCOEWNL2rIH1TCppz2QZ0SFrh2OlwGjaSQ7lYFv5ZRnw0nXS1A==}
     cpu: [x64]
     os: [linux]
 
-  '@supabase/cli-windows-arm64@2.112.0':
-    resolution: {integrity: sha512-oM9JGXaS8kV1Ft5r56/PxvP+DaP7TlyRBI0QU2FvRXQmxOf21tWFMOj881m3nv3H+eYgYjJmNlwggh8EvQNhJg==}
+  '@supabase/cli-windows-arm64@2.113.0':
+    resolution: {integrity: sha512-9Ky2zL5WPsJ1n6hJutWEist+UNpLynZWBTRohjBpssZYXNnVBq7DJYINqoWbptL6rhwbX1N3Q3FaxPndMB8hpA==}
     cpu: [arm64]
     os: [win32]
 
-  '@supabase/cli-windows-x64@2.112.0':
-    resolution: {integrity: sha512-5zW16zICZi8/FUuTzveRcPpszcYoVhTFroRuFFBXCZ8qphzOtWhjpA1nBZvTMQKN7wUNI0bVYUal7/vPVZsi2A==}
+  '@supabase/cli-windows-x64@2.113.0':
+    resolution: {integrity: sha512-l9IH4vWUQCZIJJbifHm4GZInEgCgDV4WJwvZAvHDzNfe1oUXSr26ZZPfuL1AwS4dX/4SECZsUy8AgJGjtZmSog==}
     cpu: [x64]
     os: [win32]
 
@@ -3184,8 +3184,8 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  supabase@2.112.0:
-    resolution: {integrity: sha512-JZRbKpHSR1FLyWOaDrNfjI02a4s6NuLjk9H9bCmuuWKKj1ks3utQ15c8um6k96g8LKWQKy4EKD2C3VnJ5b2TBw==}
+  supabase@2.113.0:
+    resolution: {integrity: sha512-GWlx87NpsT1opPOLWRkaTnXEUUchWmCMPVCLRU22GD+oJEH/sVnUI9NCrMZuf5XpmQE+aSbPogHW69UIbVL32w==}
     hasBin: true
 
   supports-color@10.2.2:
@@ -5160,28 +5160,28 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/cli-darwin-arm64@2.112.0':
+  '@supabase/cli-darwin-arm64@2.113.0':
     optional: true
 
-  '@supabase/cli-darwin-x64@2.112.0':
+  '@supabase/cli-darwin-x64@2.113.0':
     optional: true
 
-  '@supabase/cli-linux-arm64-musl@2.112.0':
+  '@supabase/cli-linux-arm64-musl@2.113.0':
     optional: true
 
-  '@supabase/cli-linux-arm64@2.112.0':
+  '@supabase/cli-linux-arm64@2.113.0':
     optional: true
 
-  '@supabase/cli-linux-x64-musl@2.112.0':
+  '@supabase/cli-linux-x64-musl@2.113.0':
     optional: true
 
-  '@supabase/cli-linux-x64@2.112.0':
+  '@supabase/cli-linux-x64@2.113.0':
     optional: true
 
-  '@supabase/cli-windows-arm64@2.112.0':
+  '@supabase/cli-windows-arm64@2.113.0':
     optional: true
 
-  '@supabase/cli-windows-x64@2.112.0':
+  '@supabase/cli-windows-x64@2.113.0':
     optional: true
 
   '@supabase/functions-js@2.112.2':
@@ -6625,19 +6625,19 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.8
 
-  supabase@2.112.0:
+  supabase@2.113.0:
     dependencies:
       eciesjs: 0.5.0
       jose: 6.2.8
     optionalDependencies:
-      '@supabase/cli-darwin-arm64': 2.112.0
-      '@supabase/cli-darwin-x64': 2.112.0
-      '@supabase/cli-linux-arm64': 2.112.0
-      '@supabase/cli-linux-arm64-musl': 2.112.0
-      '@supabase/cli-linux-x64': 2.112.0
-      '@supabase/cli-linux-x64-musl': 2.112.0
-      '@supabase/cli-windows-arm64': 2.112.0
-      '@supabase/cli-windows-x64': 2.112.0
+      '@supabase/cli-darwin-arm64': 2.113.0
+      '@supabase/cli-darwin-x64': 2.113.0
+      '@supabase/cli-linux-arm64': 2.113.0
+      '@supabase/cli-linux-arm64-musl': 2.113.0
+      '@supabase/cli-linux-x64': 2.113.0
+      '@supabase/cli-linux-x64-musl': 2.113.0
+      '@supabase/cli-windows-arm64': 2.113.0
+      '@supabase/cli-windows-x64': 2.113.0
 
   supports-color@10.2.2: {}
 

--- a/scripts/run-worker-deploy.mjs
+++ b/scripts/run-worker-deploy.mjs
@@ -216,7 +216,6 @@ if (!dryRun) {
     }
     if (secretFile) selected.wrangler.push('--secrets-file', secretFile.path);
   }
-  selected.wrangler.push('--yes');
 }
 
 if (dryRun) selected.wrangler.push('--dry-run');


### PR DESCRIPTION
## Summary

Make the disposable hosted-proof path match the current Supabase and Wrangler CLIs. The live staging deploy now reaches Cloudflare without changing production routes or data.

## What changed

- Document the correct migration-history treatment for a data-less Supabase branch and require an empty final schema diff.
- Pin the Supabase CLI version that parses current branch timestamps.
- Remove Wrangler's obsolete `--yes` deploy option.
- Add a regression assertion for the rejected Wrangler flag.

## Verification

- `pnpm test`: 27 test programs passed.
- `pnpm typecheck`: 8 tasks passed.
- The isolated `llmkit-proxy-staging` Worker deployed and reported the exact source commit and temporary database ref.
- The temporary Worker, Supabase branch, and local staging secret file were deleted after the run.

The hosted budget proof did not run because no provider API credential was available. This PR does not claim that proof passed.

## Review focus

Confirm that the staging path remains isolated from production and that the deployment wrapper matches Wrangler 4.114.