### PR TITLE
Constrain AI SDK provider to v6

### DIFF
--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -40,7 +40,7 @@
     "@ai-sdk/provider": "^3.0.14"
   },
   "peerDependencies": {
-    "ai": ">=6.0.0"
+    "ai": ">=6.0.0 <7.0.0"
   },
   "peerDependenciesMeta": {
     "ai": {

--- a/packages/ai-sdk-provider/test/smoke-test.mjs
+++ b/packages/ai-sdk-provider/test/smoke-test.mjs
@@ -8,7 +8,19 @@ let failed = 0;
 function test(name, fn) { tests.push({ name, fn }); }
 function assert(cond, msg) { if (!cond) throw new Error(msg); }
 
+import { readFile } from 'node:fs/promises';
+
 const mod = await import('../dist/index.js');
+const packageJson = JSON.parse(
+  await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+);
+
+test('package peer boundary matches its AI SDK v6 provider protocol', () => {
+  assert(
+    packageJson.peerDependencies?.ai === '>=6.0.0 <7.0.0',
+    `unexpected ai peer range: ${packageJson.peerDependencies?.ai}`,
+  );
+});
 
 test('createLLMKit is exported and is a function', () => {
   assert(typeof mod.createLLMKit === 'function', 'createLLMKit should be a function');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         specifier: ^3.0.14
         version: 3.0.14
       ai:
-        specifier: '>=6.0.0'
+        specifier: '>=6.0.0 <7.0.0'
         version: 6.0.137(zod@4.4.3)
     devDependencies:
       typescript:


### PR DESCRIPTION
﻿## Summary

Prevent the AI SDK v6 provider from accepting AI SDK v7, whose provider protocol is not compatible with this package's V3 implementation.

## What changed

- Constrain the optional `ai` peer dependency to `>=6.0.0 <7.0.0`.
- Keep the workspace lockfile aligned with the manifest.
- Add a package-level regression check for the declared v6 boundary.

## Verification

- `pnpm quality:pr`
- Packed `0.1.2` artifact installed with `ai@6.0.137` under strict peer resolution.
- The same artifact correctly rejected `ai@7.0.63` under strict peer resolution.

## Review focus

Confirm that the peer range matches the provider's V3 implementation and preserves existing AI SDK v6 consumers.
