### PR TITLE
Make README diagrams readable

### DIFF
--- a/.github/budget-path.svg
+++ b/.github/budget-path.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 390" role="img" aria-labelledby="title description">
+  <title id="title">LLMKit budget admission path</title>
+  <desc id="description">
+    A client request is authenticated, checked for idempotency, and assigned a cost reservation.
+    Admitted requests reach the provider, settle to actual usage, and produce a receipt. Requests
+    over budget are rejected before provider dispatch.
+  </desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8c959f" />
+    </marker>
+    <marker id="arrow-admitted" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a371f7" />
+    </marker>
+    <marker id="arrow-rejected" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f85149" />
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="5" stdDeviation="7" flood-color="#010409" flood-opacity="0.38" />
+    </filter>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="388" rx="20" fill="#0d1117" stroke="#30363d" stroke-width="2" />
+
+  <g fill="none" stroke-width="3">
+    <g stroke="#8c959f" marker-end="url(#arrow)">
+      <path d="M 295 90 H 325" />
+      <path d="M 585 90 H 615" />
+      <path d="M 875 90 H 905" />
+      <path d="M 585 296 H 615" />
+      <path d="M 875 296 H 905" />
+    </g>
+    <path d="M 985 132 V 210 H 455 V 242" stroke="#a371f7" marker-end="url(#arrow-admitted)" />
+    <path d="M 1085 132 V 175 H 165 V 242" stroke="#f85149" marker-end="url(#arrow-rejected)" />
+  </g>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <g filter="url(#shadow)">
+      <rect x="35" y="48" width="260" height="84" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+      <rect x="325" y="48" width="260" height="84" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+      <rect x="615" y="48" width="260" height="84" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+      <rect x="905" y="48" width="260" height="84" rx="12" fill="#1b1730" stroke="#a371f7" stroke-width="2" />
+
+      <rect x="35" y="248" width="260" height="96" rx="12" fill="#24181b" stroke="#f85149" stroke-width="2" />
+      <rect x="325" y="248" width="260" height="96" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+      <rect x="615" y="248" width="260" height="96" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+      <rect x="905" y="248" width="260" height="96" rx="12" fill="#161b22" stroke="#57606a" stroke-width="2" />
+    </g>
+
+    <g fill="#f0f6fc" font-size="23" font-weight="650" text-anchor="middle">
+      <text x="165" y="98">Client request</text>
+
+      <text x="455" y="83">
+        <tspan x="455" dy="0">Authenticate and</tspan>
+        <tspan x="455" dy="29">identify scope</tspan>
+      </text>
+
+      <text x="745" y="98">Idempotency gate</text>
+
+      <text x="1035" y="83">
+        <tspan x="1035" dy="0">Reserve estimated</tspan>
+        <tspan x="1035" dy="29">cost</tspan>
+      </text>
+
+      <text x="165" y="291">
+        <tspan x="165" dy="0">Reject before</tspan>
+        <tspan x="165" dy="29">provider dispatch</tspan>
+      </text>
+
+      <text x="455" y="304">Provider dispatch</text>
+      <text x="745" y="304">Settle actual usage</text>
+
+      <text x="1035" y="291">
+        <tspan x="1035" dy="0">Receipt and analytics</tspan>
+        <tspan x="1035" dy="29">outbox</tspan>
+      </text>
+    </g>
+
+    <g font-size="16" font-weight="700" letter-spacing="0.8" text-anchor="middle">
+      <rect x="673" y="191" width="104" height="28" rx="14" fill="#2b2145" />
+      <text x="725" y="211" fill="#d2a8ff">ADMITTED</text>
+
+      <rect x="350" y="156" width="124" height="28" rx="14" fill="#3a2024" />
+      <text x="412" y="176" fill="#ffb3ad">OVER BUDGET</text>
+    </g>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@
   <a href="https://llmkit.sh">Website</a> | <a href="https://llmkit.sh/docs">Docs</a> | <a href="https://api.llmkit.sh/v1/pricing/compare?input=1000&output=1000">Pricing API</a> | <a href="SECURITY.md">Security</a>
 </p>
 
-LLMKit is an open-source AI gateway and SDK suite for cost attribution, budget admission, and request evidence. The gateway reserves estimated spend before provider dispatch, rejects requests that cannot fit the active budget, and settles the reservation to actual usage when the response completes.
+LLMKit is an open-source AI gateway and SDK suite for cost attribution, budget admission, and
+request evidence. The gateway reserves estimated spend before provider dispatch. It rejects
+requests that cannot fit the active budget, then settles admitted reservations to actual usage when
+the response completes.
 
 The repository also ships local tracking surfaces that do not require an LLMKit account or proxy.
 
@@ -67,7 +70,9 @@ Use `-v` for per-request output or `--json` for machine-readable results.
 
 ### Gateway mode (existing key)
 
-Gateway examples require an existing LLMKit API key. Account creation and key management are temporarily unavailable while the authenticated service is restored. Use the local tracking paths above if you do not already have a key.
+Gateway examples require an existing LLMKit API key. Account creation and key management are
+temporarily unavailable while the authenticated service is restored. If you do not already have a
+key, use one of the local tracking paths above.
 
 ```python
 from openai import OpenAI
@@ -85,24 +90,26 @@ response = client.chat.completions.create(
 
 ## The budget path
 
-```mermaid
-flowchart LR
-    A[Client request] --> B[Authenticate and identify scope]
-    B --> C[Idempotency gate]
-    C --> D[Reserve estimated cost]
-    D -->|admitted| E[Provider dispatch]
-    D -->|over budget| F[Reject before dispatch]
-    E --> G[Settle actual usage]
-    G --> H[Receipt and analytics outbox]
-```
+<p align="center">
+  <img
+    src=".github/budget-path.svg"
+    width="100%"
+    alt="LLMKit authenticates each request, reserves its estimated cost, rejects requests over budget before provider dispatch, and settles admitted requests to actual usage."
+  />
+</p>
 
 The control path is built around three boundaries:
 
-- **Atomic admission:** a Durable Object owns reservation state for a budget scope, so concurrent requests cannot each spend the same remaining amount.
-- **Dispatch-aware idempotency:** deterministic pre-dispatch failures release the key; failures after possible provider dispatch remain terminal rather than risking duplicate spend.
-- **Bounded responses:** non-streaming bodies and individual SSE frames have explicit byte limits and cancel upstream reads when exceeded.
+- **Atomic admission:** a Durable Object owns reservation state for each budget scope. Concurrent
+  requests cannot spend the same remaining balance.
+- **Dispatch-aware idempotency:** deterministic failures before dispatch release the key. After
+  provider dispatch may have occurred, failures remain terminal to avoid duplicate spend.
+- **Bounded responses:** non-streaming bodies and individual SSE frames have explicit byte limits.
+  LLMKit cancels upstream reads when a limit is exceeded.
 
-Request receipts bind the admission decision, provider attempt, settlement, and analytics handoff with stable identifiers. Database writes use an outbox so an analytics outage does not silently erase budget evidence.
+Request receipts bind the admission decision, provider attempt, settlement, and analytics handoff
+with stable identifiers. Database writes use an outbox, so an analytics outage does not silently erase
+budget evidence.
 
 ## MCP server
 
@@ -117,11 +124,16 @@ Request receipts bind the admission decision, provider attempt, settlement, and 
 }
 ```
 
-Five local tools inspect supported Claude Code sessions and Cline task data discovered in supported editor storage without an LLMKit key. Six gateway tools query spend, budgets, keys, sessions, and service health when an existing key is configured in `LLMKIT_API_KEY`. Together they expose 11 tools.
+Five local tools inspect supported Claude Code sessions and Cline task data without an LLMKit key.
+Six gateway tools query spend, budgets, keys, sessions, and service health when `LLMKIT_API_KEY`
+contains an existing key. Together they expose 11 tools.
 
 ## Pricing data
 
-The pinned catalog is a bundled reference snapshot, not a live quote. One source file, [`packages/shared/pricing.json`](packages/shared/pricing.json), records its own snapshot date and generates the TypeScript, Python, and MCP tables; CI rejects drift between the source and generated files. The public site renders only populated provider tables and displays that source date.
+The pinned catalog is a bundled reference snapshot, not a live quote. One source file,
+[`packages/shared/pricing.json`](packages/shared/pricing.json), records the snapshot date and
+generates the TypeScript, Python, and MCP tables. CI rejects drift between the source and generated
+files. The public site renders only populated provider tables and displays the source date.
 
 The public comparison endpoint requires no account:
 
@@ -163,7 +175,9 @@ Generic deploy commands are intentionally omitted. Staging and production use se
 
 ## Security
 
-Provider credentials are encrypted with AES-256-GCM using a random IV and owner/provider-bound additional authenticated data. LLMKit API keys are hashed before storage. CI includes secret scanning, static analysis, dependency review, CodeQL, and package provenance checks.
+Provider credentials are encrypted with AES-256-GCM using a random IV and owner/provider-bound
+additional authenticated data. LLMKit API keys are hashed before storage. CI includes secret
+scanning, static analysis, dependency review, CodeQL, and package provenance checks.
 
 Read the [security policy and architecture](SECURITY.md). Please report vulnerabilities privately to `security@llmkit.sh`.
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -1,6 +1,9 @@
 # @f3d1/llmkit-ai-sdk-provider
 
-[Vercel AI SDK](https://sdk.vercel.ai) v6 custom provider for [LLMKit](https://github.com/smigolsmigol/llmkit). Routes requests through the LLMKit proxy with cost tracking, budget enforcement, and provider fallback. Hosted calls require an existing LLMKit API key while new account creation is closed; `baseUrl` can target a self-hosted deployment.
+[Vercel AI SDK](https://sdk.vercel.ai) v6 custom provider for
+[LLMKit](https://github.com/smigolsmigol/llmkit). It routes requests through the LLMKit proxy with
+cost tracking, budget enforcement, and provider fallback. Hosted calls require an existing LLMKit
+API key while new account creation is closed. Set `baseUrl` to use a self-hosted deployment.
 
 ## Install
 
@@ -53,7 +56,7 @@ createLLMKit({
 
 ## Docs
 
-Full documentation and provider setup: [github.com/smigolsmigol/llmkit](https://github.com/smigolsmigol/llmkit)
+See the [LLMKit repository](https://github.com/smigolsmigol/llmkit) for gateway and provider setup.
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
 # @f3d1/llmkit-cli
 
-Local AI cost tracking for OpenAI and Anthropic clients that honor their standard base-URL environment variables. Wrap a command, observe compatible calls through a local proxy, and print a cost summary when it exits.
+Local AI cost tracking for OpenAI and Anthropic clients that honor their standard base-URL
+environment variables. The CLI wraps a command, observes compatible calls through a local proxy,
+and prints a cost summary when the process exits.
 
 ## Usage
 
@@ -10,7 +12,8 @@ npx @f3d1/llmkit-cli -- node agent.js
 npx @f3d1/llmkit-cli -- your-binary --flag
 ```
 
-The CLI sets `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` for the child process. Calls that ignore those variables, use another protocol, or bypass that environment are not observed.
+The CLI sets `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` for the child process. It cannot observe
+calls that ignore those variables, use another protocol, or bypass that environment.
 
 ## Options
 
@@ -44,7 +47,7 @@ The numbers above illustrate the output format; actual values come from the call
 
 ## Docs
 
-Full documentation and proxy setup: [github.com/smigolsmigol/llmkit](https://github.com/smigolsmigol/llmkit)
+See the [LLMKit repository](https://github.com/smigolsmigol/llmkit) for gateway and proxy setup.
 
 ## License
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,6 +1,7 @@
 # @f3d1/llmkit-mcp-server
 
-AI cost inspection for supported Claude Code sessions and Cline task data discovered in VS Code-family storage. Eleven tools cover local session evidence plus authenticated gateway spend and budget queries.
+AI cost inspection for supported Claude Code sessions and Cline task data found in VS Code-family
+storage. Eleven tools cover local session evidence, authenticated gateway spend, and budget queries.
 
 Part of [LLMKit](https://github.com/smigolsmigol/llmkit), an open-source API gateway with cost tracking and budget enforcement.
 
@@ -19,7 +20,9 @@ Add to your `.mcp.json` (Claude Code) or `.cursor/mcp.json` (Cursor):
 }
 ```
 
-The local tools (`llmkit_local_*`) need no API key. They read supported Claude Code sessions and Cline task data found in supported editor storage. Proxy tools require an existing LLMKit API key in `LLMKIT_API_KEY`; check [llmkit.sh](https://llmkit.sh) for current account and service availability.
+The local tools (`llmkit_local_*`) need no API key. They read supported Claude Code sessions and
+Cline task data from supported editor storage. Proxy tools require an existing LLMKit API key in
+`LLMKIT_API_KEY`. Check [llmkit.sh](https://llmkit.sh) for current account and service availability.
 
 ## Tools
 
@@ -36,7 +39,7 @@ The local tools (`llmkit_local_*`) need no API key. They read supported Claude C
 
 ### Local tools (no key needed)
 
-Auto-detect installed AI coding tools and aggregate data from all of them.
+The local tools detect supported installations and aggregate their session data.
 
 | Tool | What it does |
 |------|-------------|

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -73,7 +73,9 @@ Framework integrations are optional. Install the framework you use separately.
 
 ## Sessions and gateway mode
 
-Use the hosted or self-hosted LLMKit gateway when you need shared budgets, request receipts, provider routing, or dashboard analytics. Hosted calls require an existing key; new hosted account creation and key management are temporarily unavailable.
+Use the hosted or self-hosted LLMKit gateway when you need shared budgets, request receipts,
+provider routing, or dashboard analytics. Hosted calls require an existing key. New hosted account
+creation and key management are temporarily unavailable.
 
 ```python
 from llmkit import LLMKit
@@ -121,7 +123,9 @@ completion, cost = await client.chat(
 
 ## LLMKit repository
 
-The [LLMKit monorepo](https://github.com/smigolsmigol/llmkit) also contains the Cloudflare Worker gateway, dashboard, TypeScript SDK, CLI, Vercel AI SDK provider, MCP server, database migrations, and deterministic budget-control fixtures.
+The [LLMKit monorepo](https://github.com/smigolsmigol/llmkit) also contains the Cloudflare Worker
+gateway, dashboard, TypeScript SDK, CLI, Vercel AI SDK provider, MCP server, database migrations,
+and deterministic budget-control fixtures.
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,9 @@
 # @f3d1/llmkit-sdk
 
-TypeScript client and local cost tracker for [LLMKit](https://github.com/smigolsmigol/llmkit). `CostTracker` runs locally with no account or proxy. The hosted client adds provider routing, request receipts, and budget enforcement for existing LLMKit API keys.
+TypeScript client and local cost tracker for
+[LLMKit](https://github.com/smigolsmigol/llmkit). `CostTracker` runs locally with no account or
+proxy. The hosted client adds provider routing, request receipts, and budget enforcement for
+existing LLMKit API keys.
 
 ## Install
 
@@ -12,7 +15,9 @@ pnpm add @f3d1/llmkit-sdk
 
 ## Hosted client
 
-Hosted calls require an existing LLMKit API key. Check [llmkit.sh](https://llmkit.sh) for current account and service availability. For local cost estimation with no account, skip to [CostTracker](#costtracker-local-no-proxy).
+Hosted calls require an existing LLMKit API key. Check [llmkit.sh](https://llmkit.sh) for current
+account and service availability. For local cost estimation with no account, skip to
+[CostTracker](#costtracker-local-no-proxy).
 
 ```ts
 import { LLMKit } from '@f3d1/llmkit-sdk';
@@ -28,11 +33,13 @@ console.log(res.content);
 console.log(`$${res.cost.totalCost}`); // $0.0183
 ```
 
-Every response includes token counts, cost breakdown, latency, and provider info. No extra calls needed.
+Each response includes token counts, cost breakdown, latency, and provider details.
 
 ## Chat completions
 
-The `chat()` method sends a request through the LLMKit proxy and returns a typed `LLMResponse`. The proxy handles auth, logging, budget checks, and cost calculation before forwarding to the provider.
+The `chat()` method sends a request through the LLMKit proxy and returns a typed `LLMResponse`.
+The proxy handles authentication, logging, budget checks, and cost calculation before forwarding
+the request to the provider.
 
 ```ts
 const res = await llm.chat({
@@ -96,7 +103,8 @@ The `ChatStream` class implements `AsyncIterable<string>`, so it works anywhere 
 
 ## Sessions
 
-Sessions group related requests under a single ID for cost tracking and analytics. Useful for agent loops, multi-turn conversations, or anything where you want per-task cost visibility.
+Sessions group related requests under one ID for cost tracking and analytics. Use them when an agent
+loop, multi-turn conversation, or other workflow needs per-task cost visibility.
 
 ```ts
 const agent = llm.session(); // auto-generates a UUID
@@ -261,7 +269,8 @@ try {
 }
 ```
 
-Budget enforcement happens before the request reaches the provider. If a request would push spend over the limit, it's rejected with a 402 and the budget is not charged.
+Budget enforcement happens before the request reaches the provider. A request that would exceed the
+limit is rejected with a 402, and the budget is not charged.
 
 For streaming, errors on connection throw immediately. If the stream breaks mid-response, the async iterator throws on the next `read()`.
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -5,7 +5,10 @@ Shared types, constants, and pricing data for [LLMKit](https://github.com/smigol
 ## What's in it
 
 - **TypeScript types**: `LLMRequest`, `LLMResponse`, `CostBreakdown`, `TokenUsage`, `ProviderName`, `Budget`, and more
-- **Pricing snapshot**: 731 model entries across 9 populated provider tables, dated 2026-03-25, including cache read/write rates where available. The snapshot does not encode model modality, so values are token rates only for models independently verified as token-billed. `ProviderName` also reserves Ollama and OpenRouter identifiers, but this bundled snapshot contains no priced entries for them.
+- **Pricing snapshot**: 731 model entries across 9 populated provider tables, dated 2026-03-25,
+  with cache read/write rates where available. The snapshot does not encode model modality. Values
+  are token rates only for models independently verified as token-billed. `ProviderName` reserves
+  Ollama and OpenRouter identifiers, but the snapshot contains no priced entries for them.
 - **Cost calculation**: `calculateCost()`, `calculateCostBreakdown()`, `getModelPricing()`
 - **Provider inference**: `inferProvider()` resolves a model name to its provider
 - **Error types**: shared error definitions across LLMKit packages
@@ -33,7 +36,7 @@ const pricing = getModelPricing('openai', 'gpt-4.1');
 
 ## Docs
 
-Full documentation: [github.com/smigolsmigol/llmkit](https://github.com/smigolsmigol/llmkit)
+See the [LLMKit repository](https://github.com/smigolsmigol/llmkit) for the gateway and package docs.
 
 ## License
 

--- a/test/contract-test.mjs
+++ b/test/contract-test.mjs
@@ -17,6 +17,7 @@ const { PROXY_TOOLS, LOCAL_TOOLS } = await import('../packages/mcp-server/dist/t
 const serverJson = JSON.parse(readFileSync('packages/mcp-server/server.json', 'utf8'));
 const mcpPkg = JSON.parse(readFileSync('packages/mcp-server/package.json', 'utf8'));
 const readme = readFileSync('README.md', 'utf8');
+const budgetPathDiagram = readFileSync('.github/budget-path.svg', 'utf8');
 const pyPricingData = readFileSync('packages/python-sdk/src/llmkit/_pricing_data.py', 'utf8');
 const pricingJson = JSON.parse(readFileSync('packages/shared/pricing.json', 'utf8'));
 
@@ -107,6 +108,19 @@ test('README distinguishes the bundled snapshot from provider identifiers', () =
     'README should describe pricing as a bundled reference snapshot');
   assert(!readme.includes('pricing has 11 providers'),
     'README must not turn empty provider identifiers into populated pricing coverage');
+});
+
+test('README budget path avoids GitHub Mermaid controls', () => {
+  assert(readme.includes('src=".github/budget-path.svg"'),
+    'README should render the static budget path diagram');
+  assert(!readme.includes('```mermaid'),
+    'README should not use GitHub Mermaid controls for the budget path');
+  assert(budgetPathDiagram.includes('viewBox="0 0 1200 390"'),
+    'budget path diagram should scale to the README width');
+  assert(budgetPathDiagram.includes('<title id="title">'),
+    'budget path diagram should include an accessible title');
+  assert(budgetPathDiagram.includes('<desc id="description">'),
+    'budget path diagram should include an accessible description');
 });
 
 // run


### PR DESCRIPTION
## Why

The budget path was hard to read on GitHub. Mermaid controls consumed the diagram area, and the expanded view still opened at an unhelpful scale.

## What changed

- Replace the Mermaid flow with a full-width static SVG that shows both admission outcomes without zoom controls.
- Tighten prose across the public package READMEs while preserving pricing, modality, and hosted-access boundaries.
- Add a contract test that prevents the Mermaid renderer from returning.

## Validation

- `node scripts/run-js-tests.mjs` (`JS_TEST_GATE PASS`, 28 programs)
- `node packages/dashboard/test/public-content-contract-test.mjs`
- Local link check across the seven public READMEs
- SVG XML parse and visual renders at 800 px and 1200 px

## Boundary

Docs and tests only. No runtime, pricing data, authentication, deployment, or package behavior changes.
