### PR TITLE
Publish verifiable security trust metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://pypi.org/project/llmkit-sdk/"><img src="https://img.shields.io/pypi/v/llmkit-sdk?label=python" alt="PyPI" /></a>
   <a href="https://www.npmjs.com/package/@f3d1/llmkit-mcp-server"><img src="https://img.shields.io/npm/v/@f3d1/llmkit-mcp-server?label=mcp" alt="npm" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/smigolsmigol/llmkit"><img src="https://api.scorecard.dev/projects/github.com/smigolsmigol/llmkit/badge" alt="OpenSSF Scorecard" /></a>
-  <a href="https://www.bestpractices.dev/projects/11849"><img src="https://www.bestpractices.dev/projects/11849/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://www.bestpractices.dev/projects/12288"><img src="https://www.bestpractices.dev/projects/12288/badge" alt="OpenSSF Best Practices" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license" /></a>
 </p>
 
@@ -179,7 +179,10 @@ Provider credentials are encrypted with AES-256-GCM using a random IV and owner/
 additional authenticated data. LLMKit API keys are hashed before storage. CI includes secret
 scanning, static analysis, dependency review, CodeQL, and package provenance checks.
 
-Read the [security policy and architecture](SECURITY.md). Please report vulnerabilities privately to `security@llmkit.sh`.
+Read the [security policy and architecture](SECURITY.md) and the machine-readable
+[Security Insights snapshot](security-insights.yml). Please report vulnerabilities through
+[GitHub private vulnerability reporting](https://github.com/smigolsmigol/llmkit/security/advisories/new)
+or email `security@llmkit.sh`.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,37 @@
 # Security Policy
 
-## Reporting a Vulnerability
+## Supported Versions
 
-Do not open a public issue. Email security@llmkit.sh or DM @smigolsmigol on X.
+Security fixes are applied to the latest release. Older releases are not supported unless a
+security advisory says otherwise.
 
-Include: what you found, steps to reproduce, and your assessment of impact.
+## Report a Vulnerability
 
-We acknowledge within 48 hours and fix critical issues within 7 days.
+Use [GitHub private vulnerability reporting](https://github.com/smigolsmigol/llmkit/security/advisories/new)
+when possible. If GitHub is unavailable, email `security@llmkit.sh`.
+
+Do not open a public issue, discussion, or social-media message for a suspected vulnerability.
+Include the affected component and version, impact, reproduction steps, and any proof of concept
+that is safe to share.
+
+We aim to acknowledge reports within 48 hours. After reproduction, we will confirm the scope,
+severity, and coordinated disclosure plan. Resolution time depends on impact and complexity;
+critical issues are prioritized immediately. We will keep the reporter informed while the issue is
+being investigated and fixed.
+
+LLMKit does not currently operate a paid bug bounty. We can credit reporters in the advisory when
+requested and appropriate.
+
+## Scope and Safe Testing
+
+The source in this repository, published LLMKit packages, and reachable LLMKit-hosted services are
+in scope. Reports about authorization failures, credential exposure, budget-enforcement bypasses,
+request or tenant data exposure, and supply-chain compromise are especially useful.
+
+Please test only with accounts and data you own or have permission to use. Do not degrade service
+availability, access or retain data beyond what is needed to demonstrate the issue, use social
+engineering, or publish details before a coordinated fix. Third-party provider outages and purely
+theoretical findings without a practical security impact are out of scope.
 
 ## Security Architecture
 
@@ -28,7 +53,7 @@ All CI actions pinned to commit SHAs (not mutable version tags). Every workflow 
 
 Pull requests and main-branch changes run a layered quality and security pipeline. Deployment workflows have separate environment and target gates.
 
-1. **Secret scanning**: gitleaks (full git history) + semgrep secrets ruleset + private pattern matching
+1. **Secret scanning**: gitleaks + semgrep secrets ruleset + private pattern matching
 2. **Static analysis**: semgrep security-audit rules across the entire codebase
 3. **Dependency audit**: `pnpm audit` (TS) + `pip-audit` (Python) + `bandit` (Python security linter)
 4. **Project scanner**: [KeyGuard](https://github.com/smigolsmigol/keyguard) scans for leaked secrets, credential files, vulnerable configs
@@ -50,9 +75,3 @@ Pre-commit hooks install automatically via `pnpm install` (sets `core.hooksPath`
 ### Dependency Surface
 
 The proxy has two runtime dependencies: Hono and @f3d1/llmkit-shared. Minimal attack surface by design.
-
-## Supported Versions
-
-| Version | Supported |
-| ------- | --------- |
-| latest  | Yes       |

--- a/packages/dashboard/public/.well-known/security.txt
+++ b/packages/dashboard/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: https://github.com/smigolsmigol/llmkit/security/advisories/new
+Contact: mailto:security@llmkit.sh
+Expires: 2027-02-01T00:00:00Z
+Preferred-Languages: en
+Canonical: https://llmkit.sh/.well-known/security.txt
+Policy: https://github.com/smigolsmigol/llmkit/security/policy

--- a/packages/dashboard/public/_headers
+++ b/packages/dashboard/public/_headers
@@ -1,2 +1,6 @@
 /_next/static/*
   Cache-Control: public,max-age=31536000,immutable
+
+/.well-known/security.txt
+  Cache-Control: public,max-age=3600
+  Content-Type: text/plain; charset=utf-8

--- a/packages/dashboard/test/public-content-contract-test.mjs
+++ b/packages/dashboard/test/public-content-contract-test.mjs
@@ -7,6 +7,57 @@ const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
 const readDashboard = (relativePath) => readFileSync(`${packageRoot}/${relativePath}`, 'utf8');
 const readRepo = (relativePath) => readFileSync(`${repoRoot}/${relativePath}`, 'utf8');
 
+const securityTxt = readDashboard('public/.well-known/security.txt');
+const securityTxtFields = new Map();
+for (const line of securityTxt.trim().split(/\r?\n/)) {
+  const separator = line.indexOf(':');
+  assert.ok(separator > 0, `invalid security.txt line: ${line}`);
+  const name = line.slice(0, separator);
+  const value = line.slice(separator + 1).trim();
+  const values = securityTxtFields.get(name) ?? [];
+  values.push(value);
+  securityTxtFields.set(name, values);
+}
+
+assert.deepEqual(securityTxtFields.get('Contact'), [
+  'https://github.com/smigolsmigol/llmkit/security/advisories/new',
+  'mailto:security@llmkit.sh',
+]);
+assert.deepEqual(securityTxtFields.get('Canonical'), [
+  'https://llmkit.sh/.well-known/security.txt',
+]);
+assert.deepEqual(securityTxtFields.get('Policy'), [
+  'https://github.com/smigolsmigol/llmkit/security/policy',
+]);
+assert.deepEqual(securityTxtFields.get('Preferred-Languages'), ['en']);
+
+const [securityTxtExpiry] = securityTxtFields.get('Expires') ?? [];
+const expiryTime = Date.parse(securityTxtExpiry);
+const remainingLifetime = expiryTime - Date.now();
+assert.ok(Number.isFinite(expiryTime), 'security.txt Expires must be an RFC 3339 timestamp');
+assert.ok(remainingLifetime > 0, 'security.txt must not be expired');
+assert.ok(
+  remainingLifetime < 366 * 24 * 60 * 60 * 1000,
+  'security.txt Expires must remain less than one year away',
+);
+
+const securityInsights = readRepo('security-insights.yml');
+assert.match(securityInsights, /schema-version: 2\.2\.0/);
+assert.match(securityInsights, /last-reviewed: '2026-08-13'/);
+assert.match(
+  securityInsights,
+  /https:\/\/raw\.githubusercontent\.com\/smigolsmigol\/llmkit\/main\/security-insights\.yml/,
+);
+assert.match(securityInsights, /bug-bounty-available: false/);
+assert.match(securityInsights, /https:\/\/www\.bestpractices\.dev\/projects\/12288/);
+assert.doesNotMatch(securityInsights, /example\.com|11849/);
+
+const readme = readRepo('README.md');
+assert.match(readme, /bestpractices\.dev\/projects\/12288/);
+assert.doesNotMatch(readme, /bestpractices\.dev\/projects\/11849/);
+assert.match(readme, /\[Security Insights snapshot\]\(security-insights\.yml\)/);
+assert.match(readme, /security\/advisories\/new/);
+
 const pricing = JSON.parse(readFileSync(`${repoRoot}/packages/shared/pricing.json`, 'utf8'));
 const populatedProviders = Object.entries(pricing.providers)
   .filter(([, models]) => Object.keys(models).length > 0)

--- a/packages/dashboard/test/recovery-boundary-test.mjs
+++ b/packages/dashboard/test/recovery-boundary-test.mjs
@@ -29,7 +29,7 @@ for (const [pathname, expected] of violationFixtures) {
   assert.equal(classifyRecoveryPath(pathname), expected, pathname);
 }
 
-for (const pathname of ['/', '/docs', '/pricing', '/compare', '/mcp']) {
+for (const pathname of ['/', '/docs', '/pricing', '/compare', '/mcp', '/.well-known/security.txt']) {
   assert.equal(classifyRecoveryPath(pathname), 'public', pathname);
 }
 

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,0 +1,89 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-08-13'
+  last-reviewed: '2026-08-13'
+  url: https://raw.githubusercontent.com/smigolsmigol/llmkit/main/security-insights.yml
+  comment: |
+    This file describes the security posture of the LLMKit project and this repository.
+
+project:
+  name: LLMKit
+  homepage: https://llmkit.sh
+  funding: https://github.com/sponsors/smigolsmigol
+  administrators:
+    - name: f3d1
+      affiliation: Independent
+      email: security@llmkit.sh
+      social: https://github.com/smigolsmigol
+      primary: true
+  documentation:
+    quickstart-guide: https://github.com/smigolsmigol/llmkit/blob/main/QUICKSTART.md
+    detailed-guide: https://llmkit.sh/docs
+    code-of-conduct: https://github.com/smigolsmigol/llmkit/blob/main/CODE_OF_CONDUCT.md
+    support-policy: https://github.com/smigolsmigol/llmkit/security/policy#supported-versions
+  repositories:
+    - name: llmkit
+      url: https://github.com/smigolsmigol/llmkit
+      comment: |
+        Monorepo for the LLMKit gateway, SDKs, CLI, MCP server, and public website.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: LLMKit security contact
+      affiliation: LLMKit
+      email: security@llmkit.sh
+      social: https://github.com/smigolsmigol
+      primary: true
+    policy: https://github.com/smigolsmigol/llmkit/security/policy
+    in-scope:
+      - Authorization or tenant-isolation failures
+      - Provider credential or LLMKit API key exposure
+      - Budget-enforcement or request-accounting bypasses with security impact
+      - Supply-chain compromise affecting published LLMKit artifacts
+    out-of-scope:
+      - Third-party provider outages or vulnerabilities outside LLMKit control
+      - Social engineering and denial-of-service testing
+      - Purely theoretical findings without a practical security impact
+    comment: |
+      Use GitHub private vulnerability reporting when possible. LLMKit does not currently
+      operate a paid bug bounty.
+
+repository:
+  url: https://github.com/smigolsmigol/llmkit
+  status: active
+  bug-fixes-only: false
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: f3d1
+      affiliation: Independent
+      email: security@llmkit.sh
+      social: https://github.com/smigolsmigol
+      primary: true
+  documentation:
+    contributing-guide: https://github.com/smigolsmigol/llmkit/blob/main/CONTRIBUTING.md
+    security-policy: https://github.com/smigolsmigol/llmkit/security/policy
+  license:
+    url: https://github.com/smigolsmigol/llmkit/blob/main/LICENSE
+    expression: MIT
+  release:
+    automated-pipeline: true
+    changelog: https://github.com/smigolsmigol/llmkit/releases/tag/{version}
+    distribution-points:
+      - uri: https://github.com/smigolsmigol/llmkit/releases
+        comment: GitHub releases
+      - uri: https://www.npmjs.com/org/f3d1
+        comment: Published JavaScript packages
+      - uri: https://pypi.org/project/llmkit-sdk/
+        comment: Published Python SDK
+  security:
+    assessments:
+      self:
+        name: OpenSSF Best Practices self-assessment
+        evidence: https://www.bestpractices.dev/projects/12288
+        date: '2026-08-13'
+        comment: |
+          LLMKit has a passing OpenSSF Best Practices badge. This is a maintainer
+          self-assessment, not an independent security audit.


### PR DESCRIPTION
﻿## Outcome

Publish one verifiable security-disclosure contract for maintainers, researchers, and automated security tools.

## What changed

- Correct the OpenSSF Best Practices badge to LLMKit project 12288.
- Add RFC 9116 `/.well-known/security.txt` with the live GitHub private-reporting path, email fallback, policy URL, canonical URL, and bounded expiry.
- Add a Security Insights v2.2.0 snapshot with explicit self-assessment and no-bounty boundaries.
- Rewrite the reporting policy around coordinated disclosure, safe testing, scope, response expectations, and supported versions.
- Add contract coverage for badge identity, disclosure fields, expiry, public recovery routing, and Security Insights links.

## Boundaries

- No API, database, tenant, auth, package, pricing, or provider behavior changes.
- No production deployment is included in this PR.
- No OSPS workflow or new repository secret is added. The current marketplace scanner requires a separate repository-scoped PAT, so the bounded assessment will run after merge through the LFX path or another token-isolated execution.
- The OpenSSF project record and LFX onboarding remain external post-merge steps.

## Proof

- GitHub private vulnerability reporting: enabled and read back as `true`.
- Security Insights: official v2.2.0 CUE schema PASS.
- Dashboard contracts and typecheck: PASS.
- Repository static/security gate: PASS, including gitleaks, Semgrep, Bandit, KeyGuard, actionlint, Ruff, Mypy, Biome, Knip, and Publint.
- JavaScript gate: PASS, 28 programs.
- Linux OpenNext production build: PASS, 26 pages.
- Asset copy: source and generated `security.txt` SHA-256 both `AC0D13D39B66472BEA519B00A4F11FF53F32CD0122ADFD6B99DC88F8F0D3EED4`.
- Wrangler staging dry-run: PASS, 106 assets.

## Review state

Draft until required CI is green on exact head `60561002459b93b5954fa9c3ed147e316e45cc24`. Human approval remains required before merge.
