### PR TITLE
fix(ci): isolate budget falsifier background work

### DIFF
--- a/packages/proxy/test/budget-falsifier/gate0.test.ts
+++ b/packages/proxy/test/budget-falsifier/gate0.test.ts
@@ -1,4 +1,10 @@
-import { createExecutionContext, runInDurableObject, waitOnExecutionContext } from 'cloudflare:test';
+import {
+  createExecutionContext,
+  evictAllDurableObjects,
+  reset,
+  runInDurableObject,
+  waitOnExecutionContext,
+} from 'cloudflare:test';
 import { env, exports } from 'cloudflare:workers';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { encrypt } from '../../src/crypto';
@@ -282,9 +288,16 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  activeProvider = undefined;
-  vi.restoreAllMocks();
+afterEach(async () => {
+  try {
+    // Keep the outbound fetch capture installed until Durable Object waitUntil()
+    // work has drained, then remove alarms and storage before the next shard.
+    await evictAllDurableObjects();
+    await reset();
+  } finally {
+    activeProvider = undefined;
+    vi.restoreAllMocks();
+  }
 });
 
 function hardStub(budgetId: string): DurableObjectStub<BudgetDO> {

--- a/scripts/run-budget-falsifier.mjs
+++ b/scripts/run-budget-falsifier.mjs
@@ -202,7 +202,11 @@ receipt.computedVerdict = {
   localCoordinationLatency: localCoordinationLatency?.passed === true,
 };
 receipt.shards = shardEvidence;
-if (!Object.values(receipt.computedVerdict).every(Boolean)) exitCode = 1;
+const failedShards = shardEvidence.filter((shard) => shard.exitCode !== 0 || !shard.receipt);
+const failedVerdicts = Object.entries(receipt.computedVerdict)
+  .filter(([, passed]) => !passed)
+  .map(([name]) => name);
+if (failedShards.length > 0 || failedVerdicts.length > 0) exitCode = 1;
 const packageJson = JSON.parse(await readFile(resolve(packageRoot, 'package.json'), 'utf8'));
 receipt.generatedAtUtc = new Date().toISOString();
 receipt.sourceCommit = required('git', ['rev-parse', 'HEAD'], { cwd: repoRoot });
@@ -221,4 +225,8 @@ await mkdir(dirname(output), { recursive: true });
 await writeFile(output, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
 const receiptSha256 = createHash('sha256').update(await readFile(output)).digest('hex');
 process.stdout.write(`\nBUDGET_FALSIFIER_RECEIPT ${output}\nBUDGET_FALSIFIER_SHA256 ${receiptSha256}\n`);
+if (exitCode !== 0) {
+  process.stderr.write(`BUDGET_FALSIFIER_FAILED_SHARDS ${JSON.stringify(failedShards)}\n`);
+  process.stderr.write(`BUDGET_FALSIFIER_FAILED_VERDICTS ${JSON.stringify(failedVerdicts)}\n`);
+}
 process.exit(exitCode);


### PR DESCRIPTION
## Why

Main CI run [31667269877](https://github.com/smigolsmigol/llmkit/actions/runs/31667269877) failed even though the merged tree was byte-identical to the green PR head. The budget falsifier completed its assertions, then Durable Object background work outlived the per-test fetch spy and attempted real DNS for `proof-db.invalid`.

## What changed

- Gracefully drain Durable Object `waitUntil()` work while the captured outbound fetch is still installed.
- Delete test Durable Object state and alarms before restoring globals.
- Print the exact failed shard and aggregate verdict keys whenever the wrapper exits nonzero.

Production Worker behavior is unchanged. Both modified files are test and CI infrastructure.

## Proof

- Budget falsifier TypeScript typecheck: PASS
- Biome check on both changed files: PASS, with only three pre-existing warnings in the large proof file
- Original failing hard shard: PASS, no DNS escape or unhandled workerd exception
- Full 13-shard Linux run using the exact main dependency image: 0 DNS escapes, 0 unhandled workerd exceptions, 12 functional shards PASS
- Full Windows run: same 12 functional shards PASS and the new diagnostics correctly identified only the host-sensitive local latency benchmark

The Docker and Windows runs exceeded the benchmark's frozen native-runner latency threshold. This PR remains draft until GitHub's exact-head native Linux `quality-pr` result establishes that platform-specific gate.