### PR TITLE
fix(pricing): require explicit comparable models

### DIFF
--- a/API.md
+++ b/API.md
@@ -354,60 +354,86 @@ curl -X POST https://api.llmkit.sh/v1/responses \
 
 ## GET /v1/pricing/compare
 
-Public endpoint. No auth required. Compare costs across the 731 model entries in the bundled
-pricing snapshot dated 2026-03-25. This is a reference snapshot, not a live provider quote.
-The snapshot does not encode model modality. Interpret input and output values as token rates only
-for models you have independently verified are billed per token.
+Public endpoint. No auth required. Estimate costs for up to 20 exact model keys from the bundled
+pricing snapshot dated 2026-03-25. This is a reference snapshot, not a live provider quote or a
+cheapest-model recommendation. The snapshot does not encode model modality, so callers must select
+models they have independently verified are billed per input and output token.
 
 ### Query parameters
 
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `input` | number | 0 | Input tokens to price |
-| `output` | number | 0 | Output tokens to price |
-| `cacheRead` | number | 0 | Cache read tokens |
-| `cacheWrite` | number | 0 | Cache write tokens |
-| `provider` | string | all | Filter to one provider |
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mode` | string | yes | Must be `text-token` |
+| `models` | string | yes | Comma-separated exact `provider/model` keys, maximum 20 |
+| `input` | non-negative integer | yes | Input tokens to price |
+| `output` | non-negative integer | yes | Output tokens to price |
+| `cacheRead` | non-negative integer | yes | Cache read tokens |
+| `cacheWrite` | non-negative integer | yes | Cache write tokens |
+
+Every parameter must appear exactly once. Empty, negative, fractional, non-finite, unsafe integer,
+duplicate, unknown model, and unknown query values are rejected with `400 INVALID_PRICING_QUERY` or
+`400 UNKNOWN_PRICING_MODEL`. At least one token count must be greater than zero.
 
 ### Response
 
 ```json
 {
-  "input": 1000,
-  "output": 1000,
-  "cacheRead": 0,
-  "cacheWrite": 0,
-  "provider": "all",
-  "count": 731,
+  "schemaVersion": 2,
+  "snapshot": {
+    "date": "2026-03-25",
+    "liveQuote": false,
+    "sourceModalityEncoded": false,
+    "rateUnit": "USD_PER_MILLION_TOKENS"
+  },
+  "selection": {
+    "mode": "text-token",
+    "basis": "explicit-model-keys",
+    "recommendation": false
+  },
+  "usage": {
+    "input": 1000,
+    "output": 1000,
+    "cacheRead": 0,
+    "cacheWrite": 0
+  },
+  "count": 1,
   "models": [
     {
-      "provider": "gemini",
-      "model": "gemini-2.0-flash-lite",
-      "inputCost": 0.000075,
-      "outputCost": 0.0003,
-      "totalCost": 0.000375
-    },
-    {
-      "provider": "deepseek",
-      "model": "deepseek-chat",
-      "inputCost": 0.00014,
-      "outputCost": 0.00028,
-      "totalCost": 0.00042
+      "key": "openai/gpt-4o",
+      "provider": "openai",
+      "model": "gpt-4o",
+      "rates": {
+        "inputPerMillion": 2.5,
+        "outputPerMillion": 10,
+        "cacheReadPerMillion": 1.25,
+        "cacheWritePerMillion": null
+      },
+      "costs": {
+        "input": 0.0025,
+        "output": 0.01,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "total": 0.0125,
+        "currency": "USD"
+      }
     }
+  ],
+  "exclusions": [
+    "Model modality is not encoded in the source snapshot; callers must verify that every selected model is token-billed."
   ]
 }
 ```
 
-Models are sorted by `totalCost` ascending (cheapest first). Response is cached for 1 hour.
+Selected models are sorted by total estimate, then provider and model for deterministic ties. This
+ordering compares only the caller's explicit selection and is not a global recommendation. Responses
+are cached for 1 hour. Rate-limit failures remain `429 RATE_LIMITED` and are separate from pricing
+input validation.
 
 ### curl example
 
 ```bash
-# Compare cost of 10k input + 2k output tokens across all providers
-curl "https://api.llmkit.sh/v1/pricing/compare?input=10000&output=2000"
-
-# Filter to Anthropic only
-curl "https://api.llmkit.sh/v1/pricing/compare?input=10000&output=2000&provider=anthropic"
+# Compare two exact model entries you have verified are token-billed
+curl "https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=10000&output=2000&cacheRead=0&cacheWrite=0"
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `/compare` cost calculator page on the dashboard
 
 ### Fixed
+- Restricted the public pricing comparison API to explicit exact model keys, rejected invalid token counts, and removed global cross-modality ranking behavior
 - 15 adapter fixes from cross-reference audit
 - xAI tool name mapping, o1-mini pricing, grok-4 alias
 - Mobile responsive pass 2 (nav collapse, grids, widget, gradients)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://llmkit.sh">Website</a> | <a href="https://llmkit.sh/docs">Docs</a> | <a href="https://api.llmkit.sh/v1/pricing/compare?input=1000&output=1000">Pricing API</a> | <a href="SECURITY.md">Security</a>
+  <a href="https://llmkit.sh">Website</a> | <a href="https://llmkit.sh/docs">Docs</a> | <a href="https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=1000&output=1000&cacheRead=0&cacheWrite=0">Pricing API</a> | <a href="SECURITY.md">Security</a>
 </p>
 
 LLMKit is an open-source AI gateway and SDK suite for cost attribution, budget admission, and
@@ -138,10 +138,12 @@ files. The public site renders only populated provider tables and displays the s
 The public comparison endpoint requires no account:
 
 ```text
-https://api.llmkit.sh/v1/pricing/compare?input=1000&output=1000
+https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=1000&output=1000&cacheRead=0&cacheWrite=0
 ```
 
-Pricing is an estimate, not a provider invoice. Provider billing rules and catalog freshness remain part of the error boundary.
+The endpoint prices only the exact model keys supplied by the caller. It does not search for or
+recommend the cheapest model. Pricing is an estimate, not a provider invoice. Provider billing rules,
+model modality, and catalog freshness remain part of the error boundary.
 
 ## Evidence and current boundary
 

--- a/packages/dashboard/src/app/(public)/compare/calculator.tsx
+++ b/packages/dashboard/src/app/(public)/compare/calculator.tsx
@@ -191,7 +191,7 @@ export function Calculator({ models, providers, pricingSnapshotDate }: Props) {
         Search-gated estimates cover up to 50 matching rows from {models.length} model entries across {providers.length} populated provider tables.
         {' '}Bundled snapshot: {pricingSnapshotDate}. For verified token-billed models, estimates exclude cache tiers, tools, media, batch discounts, taxes, and negotiated rates.
         {' '}<a href="/pricing" className="text-violet-400 hover:text-violet-300">Full table</a>
-        {' | '}<a href="https://api.llmkit.sh/v1/pricing/compare?input=1000&output=500" className="text-violet-400 hover:text-violet-300">API</a>
+        {' | '}<a href="https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=1000&output=500&cacheRead=0&cacheWrite=0" className="text-violet-400 hover:text-violet-300">API</a>
       </p>
     </div>
   );

--- a/packages/dashboard/src/app/(public)/pricing/page.tsx
+++ b/packages/dashboard/src/app/(public)/pricing/page.tsx
@@ -36,7 +36,7 @@ export default function PricingPage() {
         title="Provider pricing without the tab graveyard."
         description={<>{models.length} priced model entries across {providers.length} populated provider tables. The bundled schema exposes input and output rates but does not encode model modality.</>}
         aside={(
-          <a href="https://api.llmkit.sh/v1/pricing/compare?input=1000&output=500" className="public-panel-soft block rounded-xl p-4 font-mono text-[10px] leading-5 text-zinc-500 transition hover:border-violet-300/25 hover:text-zinc-300">
+          <a href="https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=1000&output=500&cacheRead=0&cacheWrite=0" className="public-panel-soft block rounded-xl p-4 font-mono text-[10px] leading-5 text-zinc-500 transition hover:border-violet-300/25 hover:text-zinc-300">
             <span className="text-cyan-300">GET</span> /v1/pricing/compare<br />programmatic access
           </a>
         )}

--- a/packages/dashboard/src/app/(public)/providers/[name]/page.tsx
+++ b/packages/dashboard/src/app/(public)/providers/[name]/page.tsx
@@ -156,7 +156,7 @@ export default async function ProviderPage({ params }: { params: Promise<{ name:
           </Link>
           <span className="text-zinc-600">|</span>
           <a
-            href="https://api.llmkit.sh/v1/pricing/compare?input=1000&output=500"
+            href="https://api.llmkit.sh/v1/pricing/compare?mode=text-token&models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o&input=1000&output=500&cacheRead=0&cacheWrite=0"
             className="text-violet-400 hover:text-violet-300 transition"
             target="_blank"
             rel="noopener noreferrer"

--- a/packages/dashboard/test/public-content-contract-test.mjs
+++ b/packages/dashboard/test/public-content-contract-test.mjs
@@ -170,6 +170,22 @@ assert.match(
   'the calculator must stay empty until a specific model search is provided',
 );
 
+const pricingApiReferences = [
+  readRepo('README.md'),
+  readRepo('API.md'),
+  readDashboard('src/app/(public)/pricing/page.tsx'),
+  readDashboard('src/app/(public)/providers/[name]/page.tsx'),
+  readDashboard('src/app/(public)/compare/calculator.tsx'),
+].join('\n');
+assert.doesNotMatch(
+  pricingApiReferences,
+  /pricing\/compare\?input=/,
+  'public pricing API links must not trigger an implicit all-model ranking',
+);
+assert.match(pricingApiReferences, /mode=text-token/);
+assert.match(pricingApiReferences, /models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o/);
+assert.match(pricingApiReferences, /cacheRead=0&cacheWrite=0/);
+
 console.log(
   `PUBLIC_CONTENT_CONTRACT PASS (${modelCount} model entries, ${populatedProviders.length} populated providers, snapshot ${pricing.updatedAt})`,
 );

--- a/packages/proxy/src/do/ratelimit-do.ts
+++ b/packages/proxy/src/do/ratelimit-do.ts
@@ -52,7 +52,10 @@ export class RateLimitDO extends DurableObject {
     }
 
     this.count++;
-    await this.ctx.storage.put({ count: this.count, window: this.window });
+    await this.ctx.storage.transaction(async (storage) => {
+      await storage.put({ count: this.count, window: this.window });
+      await storage.setAlarm((this.window + 1) * 60_000);
+    });
 
     return {
       allowed: true,
@@ -72,6 +75,22 @@ export class RateLimitDO extends DurableObject {
   }
 
   async stagingProofPurge(): Promise<void> {
+    await this.ctx.storage.deleteAlarm();
+    await this.ctx.storage.deleteAll();
+    this.count = 0;
+    this.window = 0;
+    this.loaded = true;
+  }
+
+  async alarm(): Promise<void> {
+    await this.load();
+    const currentMinute = Math.floor(Date.now() / 60_000);
+    if (currentMinute <= this.window) {
+      await this.ctx.storage.setAlarm((this.window + 1) * 60_000);
+      return;
+    }
+
+    await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();
     this.count = 0;
     this.window = 0;

--- a/packages/proxy/src/routes/pricing.ts
+++ b/packages/proxy/src/routes/pricing.ts
@@ -1,50 +1,179 @@
-import { calculateCostFromPricing, PRICING } from '@f3d1/llmkit-shared';
-import { Hono } from 'hono';
+import {
+  calculateCostFromPricing,
+  type ModelPricing,
+  PRICING,
+  PRICING_UPDATED_AT,
+} from '@f3d1/llmkit-shared';
+import { type Context, Hono } from 'hono';
 import type { Env } from '../env';
 
-const pricingRequests = new Map<string, number>();
 const PRICING_RPM = 30;
+const MAX_MODELS = 20;
+const REQUIRED_QUERY_FIELDS = ['mode', 'models', 'input', 'output', 'cacheRead', 'cacheWrite'] as const;
+const ALLOWED_QUERY_FIELDS = new Set<string>(REQUIRED_QUERY_FIELDS);
+
+interface SelectedModel {
+  key: string;
+  provider: string;
+  model: string;
+  pricing: ModelPricing;
+}
 
 export const pricingRouter = new Hono<Env>();
 
-pricingRouter.get('/pricing/compare', (c) => {
-  const ip = c.req.header('cf-connecting-ip') || 'unknown';
-  const window = Math.floor(Date.now() / 60_000);
-  const key = `${ip}:${window}`;
-  const count = (pricingRequests.get(key) || 0) + 1;
-  pricingRequests.set(key, count);
-  if (count > PRICING_RPM) {
+pricingRouter.get('/pricing/compare', async (c) => {
+  const clientIdentity = c.req.header('cf-connecting-ip') || 'unknown';
+  const limiterName = `public-pricing:${clientIdentity}`;
+  const limiter = c.env.RATE_LIMIT_DO.get(c.env.RATE_LIMIT_DO.idFromName(limiterName));
+  const rate = await limiter.hit({ limit: PRICING_RPM });
+  c.header('X-RateLimit-Limit', String(rate.limit));
+  c.header('X-RateLimit-Remaining', String(rate.remaining));
+  if (!rate.allowed) {
+    c.header('Retry-After', String(rate.retryAfterSeconds ?? 60));
+    c.header('Cache-Control', 'no-store');
     return c.json({ error: { code: 'RATE_LIMITED', message: 'pricing API rate limit exceeded' } }, 429);
   }
-  // clean old windows
-  for (const [k] of pricingRequests) { if (!k.endsWith(`:${window}`)) pricingRequests.delete(k); }
-  const input = Number(c.req.query('input')) || 0;
-  const output = Number(c.req.query('output')) || 0;
-  const cacheRead = Number(c.req.query('cacheRead')) || 0;
-  const cacheWrite = Number(c.req.query('cacheWrite')) || 0;
-  const filterProvider = c.req.query('provider') || undefined;
 
-  const usage = { inputTokens: input, outputTokens: output, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite, totalTokens: input + output };
-  const models: Array<{ provider: string; model: string; inputCost: number; outputCost: number; cacheReadCost?: number; totalCost: number }> = [];
-
-  for (const [provider, table] of Object.entries(PRICING)) {
-    if (filterProvider && provider !== filterProvider) continue;
-
-    for (const [model, pricing] of Object.entries(table)) {
-      const cost = calculateCostFromPricing(pricing, usage);
-      models.push({
-        provider,
-        model,
-        inputCost: cost.inputCost,
-        outputCost: cost.outputCost,
-        cacheReadCost: cost.cacheReadCost,
-        totalCost: cost.totalCost,
-      });
+  const params = new URL(c.req.url).searchParams;
+  for (const name of params.keys()) {
+    if (!ALLOWED_QUERY_FIELDS.has(name)) {
+      return invalidQuery(c, `unknown query parameter: ${name}`, name);
     }
   }
 
-  models.sort((a, b) => a.totalCost - b.totalCost);
+  const values = new Map<string, string>();
+  for (const name of REQUIRED_QUERY_FIELDS) {
+    const matches = params.getAll(name);
+    if (matches.length !== 1 || matches[0]!.trim() === '') {
+      const reason = matches.length > 1 ? 'must appear exactly once' : 'is required and cannot be empty';
+      return invalidQuery(c, `${name} ${reason}`, name);
+    }
+    values.set(name, matches[0]!);
+  }
+
+  if (values.get('mode') !== 'text-token') {
+    return invalidQuery(c, 'mode must be text-token', 'mode');
+  }
+
+  const parsedInput = parseTokenCount(values.get('input')!, 'input');
+  if (typeof parsedInput === 'string') return invalidTokenCount(c, parsedInput);
+  const parsedOutput = parseTokenCount(values.get('output')!, 'output');
+  if (typeof parsedOutput === 'string') return invalidTokenCount(c, parsedOutput);
+  const parsedCacheRead = parseTokenCount(values.get('cacheRead')!, 'cacheRead');
+  if (typeof parsedCacheRead === 'string') return invalidTokenCount(c, parsedCacheRead);
+  const parsedCacheWrite = parseTokenCount(values.get('cacheWrite')!, 'cacheWrite');
+  if (typeof parsedCacheWrite === 'string') return invalidTokenCount(c, parsedCacheWrite);
+  const input = parsedInput;
+  const output = parsedOutput;
+  const cacheRead = parsedCacheRead;
+  const cacheWrite = parsedCacheWrite;
+  if (input + output + cacheRead + cacheWrite === 0) {
+    return invalidQuery(c, 'at least one token count must be greater than zero', 'usage');
+  }
+
+  const modelKeys = values.get('models')!.split(',');
+  if (modelKeys.some((key) => key.trim() !== key || key === '')) {
+    return invalidQuery(c, 'models must be a comma-separated list of exact provider/model keys', 'models');
+  }
+  if (modelKeys.length > MAX_MODELS) {
+    return invalidQuery(c, `models accepts at most ${MAX_MODELS} keys`, 'models');
+  }
+  if (new Set(modelKeys).size !== modelKeys.length) {
+    return invalidQuery(c, 'models cannot contain duplicate keys', 'models');
+  }
+
+  const selected: SelectedModel[] = [];
+  const pricingTables = PRICING as Record<string, Record<string, ModelPricing>>;
+  for (const key of modelKeys) {
+    const separator = key.indexOf('/');
+    if (separator <= 0 || separator === key.length - 1) {
+      return invalidQuery(c, `invalid model key: ${key}`, 'models');
+    }
+    const provider = key.slice(0, separator);
+    const model = key.slice(separator + 1);
+    const pricing = pricingTables[provider]?.[model];
+    if (!pricing) {
+      return c.json({ error: { code: 'UNKNOWN_PRICING_MODEL', message: `unknown exact model key: ${key}`, field: 'models' } }, 400);
+    }
+    selected.push({ key, provider, model, pricing });
+  }
+
+  const usage = { inputTokens: input, outputTokens: output, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite, totalTokens: input + output };
+  const models = selected.map(({ key: modelKey, provider, model, pricing }) => {
+    const cost = calculateCostFromPricing(pricing, usage);
+    return {
+      key: modelKey,
+      provider,
+      model,
+      rates: {
+        inputPerMillion: pricing.inputPerMillion,
+        outputPerMillion: pricing.outputPerMillion,
+        cacheReadPerMillion: pricing.cacheReadPerMillion ?? null,
+        cacheWritePerMillion: pricing.cacheWritePerMillion ?? null,
+      },
+      costs: {
+        input: cost.inputCost,
+        output: cost.outputCost,
+        cacheRead: cost.cacheReadCost ?? 0,
+        cacheWrite: cost.cacheWriteCost ?? 0,
+        total: cost.totalCost,
+        currency: cost.currency,
+      },
+    };
+  });
+
+  models.sort((left, right) => (
+    left.costs.total - right.costs.total
+    || compareText(left.provider, right.provider)
+    || compareText(left.model, right.model)
+  ));
 
   c.header('Cache-Control', 'public, max-age=3600');
-  return c.json({ input, output, cacheRead, cacheWrite, provider: filterProvider || 'all', count: models.length, models });
+  return c.json({
+    schemaVersion: 2,
+    snapshot: {
+      date: PRICING_UPDATED_AT,
+      liveQuote: false,
+      sourceModalityEncoded: false,
+      rateUnit: 'USD_PER_MILLION_TOKENS',
+    },
+    selection: {
+      mode: 'text-token',
+      basis: 'explicit-model-keys',
+      recommendation: false,
+    },
+    usage: { input, output, cacheRead, cacheWrite },
+    count: models.length,
+    models,
+    exclusions: [
+      'Model modality is not encoded in the source snapshot; callers must verify that every selected model is token-billed.',
+      'Estimates exclude tools, media, batch discounts, taxes, negotiated rates, and provider-specific billing rules.',
+    ],
+  });
 });
+
+function parseTokenCount(raw: string, field: string): number | string {
+  if (!/^(0|[1-9]\d*)$/.test(raw)) {
+    return `${field}:must be a non-negative base-10 integer`;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    return `${field}:must be a safe integer`;
+  }
+  return value;
+}
+
+function invalidTokenCount(c: Context<Env>, failure: string) {
+  const separator = failure.indexOf(':');
+  return invalidQuery(c, failure.slice(separator + 1), failure.slice(0, separator));
+}
+
+function invalidQuery(c: Context<Env>, message: string, field: string) {
+  return c.json({ error: { code: 'INVALID_PRICING_QUERY', message, field } }, 400);
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/packages/proxy/test/budget-falsifier/staging-proof.test.ts
+++ b/packages/proxy/test/budget-falsifier/staging-proof.test.ts
@@ -1,4 +1,9 @@
-import { env, runInDurableObject } from 'cloudflare:test';
+import {
+  env,
+  evictAllDurableObjects,
+  runDurableObjectAlarm,
+  runInDurableObject,
+} from 'cloudflare:test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BudgetDO, BudgetState } from '../../src/do/budget-do';
 import type { IdempotencyDO } from '../../src/do/idempotency-do';
@@ -33,6 +38,77 @@ function proofRequest(path: string, init: RequestInit = {}, overrides: Partial<E
 }
 
 describe('isolated staging proof surface', () => {
+  it('shares the public pricing limit across Worker and Durable Object restarts', async () => {
+    const clientIp = '198.51.100.77';
+    const objectName = `public-pricing:${clientIp}`;
+    const stub = env.RATE_LIMIT_DO.get(env.RATE_LIMIT_DO.idFromName(objectName));
+    await stub.stagingProofPurge();
+
+    const query = [
+      'mode=text-token',
+      'models=openai%2Fgpt-4o',
+      'input=1',
+      'output=0',
+      'cacheRead=0',
+      'cacheWrite=0',
+    ].join('&');
+    const hit = () => stagingApp.request(`/v1/pricing/compare?${query}`, {
+      headers: { 'cf-connecting-ip': clientIp },
+    }, bindings());
+
+    try {
+      for (let index = 0; index < 15; index++) {
+        const response = await hit();
+        expect(response.status).toBe(200);
+      }
+
+      await evictAllDurableObjects();
+
+      for (let index = 15; index < 30; index++) {
+        const response = await hit();
+        expect(response.status).toBe(200);
+      }
+
+      const blocked = await hit();
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers.get('x-ratelimit-limit')).toBe('30');
+      expect(blocked.headers.get('x-ratelimit-remaining')).toBe('0');
+      expect(Number(blocked.headers.get('retry-after'))).toBeGreaterThan(0);
+      expect(await blocked.json()).toEqual({
+        error: { code: 'RATE_LIMITED', message: 'pricing API rate limit exceeded' },
+      });
+
+      const currentStub = env.RATE_LIMIT_DO.get(env.RATE_LIMIT_DO.idFromName(objectName));
+      await runInDurableObject(currentStub, async (_instance, state) => {
+        await state.storage.put('window', Math.floor(Date.now() / 60_000));
+        await state.storage.setAlarm(Date.now() + 60_000);
+      });
+      expect(await runDurableObjectAlarm(currentStub)).toBe(true);
+      await evictAllDurableObjects();
+      expect((await hit()).status).toBe(429);
+
+      const retainedStub = env.RATE_LIMIT_DO.get(env.RATE_LIMIT_DO.idFromName(objectName));
+      await runInDurableObject(retainedStub, async (_instance, state) => {
+        await state.storage.put('window', Math.floor(Date.now() / 60_000) - 1);
+        await state.storage.setAlarm(Date.now() + 60_000);
+      });
+      await evictAllDurableObjects();
+      const expiredStub = env.RATE_LIMIT_DO.get(env.RATE_LIMIT_DO.idFromName(objectName));
+      expect(await runDurableObjectAlarm(expiredStub)).toBe(true);
+      await runInDurableObject(expiredStub, async (_instance, state) => {
+        await expect(state.storage.list()).resolves.toHaveProperty('size', 0);
+        await expect(state.storage.getAlarm()).resolves.toBeNull();
+      });
+
+      const afterExpiry = await hit();
+      expect(afterExpiry.status).toBe(200);
+      expect(afterExpiry.headers.get('x-ratelimit-remaining')).toBe('29');
+    } finally {
+      const currentStub = env.RATE_LIMIT_DO.get(env.RATE_LIMIT_DO.idFromName(objectName));
+      await currentStub.stagingProofPurge();
+    }
+  });
+
   it('fails closed on disabled proof mode, database drift, and bad authorization', async () => {
     const budgetId = crypto.randomUUID();
     const disabled = await proofRequest(`${PROOF_PREFIX}/budget/${budgetId}`, {}, {

--- a/packages/proxy/test/pricing-route.test.ts
+++ b/packages/proxy/test/pricing-route.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../src/env';
+import { pricingRouter } from '../src/routes/pricing';
+
+let requestId = 0;
+
+interface PricingModelResponse {
+  key: string;
+  rates: Record<string, number | null>;
+  costs: Record<string, number | string>;
+}
+
+interface PricingResponse {
+  schemaVersion: number;
+  snapshot: Record<string, string | boolean>;
+  selection: Record<string, string | boolean>;
+  usage: Record<string, number>;
+  models: PricingModelResponse[];
+}
+
+interface ErrorResponse {
+  error: {
+    code: string;
+    field: string;
+  };
+}
+
+const allowAllRateLimit = {
+  idFromName: (name: string) => name,
+  get: () => ({
+    hit: async ({ limit }: { limit: number }) => ({
+      allowed: true,
+      count: 1,
+      limit,
+      remaining: limit - 1,
+    }),
+  }),
+};
+
+const bindings = {
+  RATE_LIMIT_DO: allowAllRateLimit,
+} as unknown as Env['Bindings'];
+
+function request(query: string): Promise<Response> {
+  requestId += 1;
+  return pricingRouter.request(`https://api.llmkit.test/pricing/compare?${query}`, {
+    headers: { 'cf-connecting-ip': `198.51.100.${requestId}` },
+  }, bindings);
+}
+
+async function json<T>(response: Response): Promise<T> {
+  return await response.json() as T;
+}
+
+const VALID_QUERY = [
+  'mode=text-token',
+  'models=anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o',
+  'input=1000',
+  'output=500',
+  'cacheRead=0',
+  'cacheWrite=0',
+].join('&');
+
+describe('GET /pricing/compare', () => {
+  it('prices only explicit exact model keys and returns the snapshot boundary', async () => {
+    const response = await request(VALID_QUERY);
+    const body = await json<PricingResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.schemaVersion).toBe(2);
+    expect(body.snapshot).toMatchObject({
+      date: '2026-03-25',
+      liveQuote: false,
+      sourceModalityEncoded: false,
+      rateUnit: 'USD_PER_MILLION_TOKENS',
+    });
+    expect(body.selection).toEqual({
+      mode: 'text-token',
+      basis: 'explicit-model-keys',
+      recommendation: false,
+    });
+    expect(body.usage).toEqual({ input: 1000, output: 500, cacheRead: 0, cacheWrite: 0 });
+    expect(body.models).toHaveLength(2);
+    expect(body.models.map((entry) => entry.key).sort()).toEqual([
+      'anthropic/claude-sonnet-4-6',
+      'openai/gpt-4o',
+    ]);
+    for (const entry of body.models) {
+      expect(entry.rates).toEqual(expect.objectContaining({
+        inputPerMillion: expect.any(Number),
+        outputPerMillion: expect.any(Number),
+      }));
+      expect(entry.costs).toEqual(expect.objectContaining({
+        input: expect.any(Number),
+        output: expect.any(Number),
+        cacheRead: expect.any(Number),
+        cacheWrite: expect.any(Number),
+        total: expect.any(Number),
+        currency: 'USD',
+      }));
+    }
+  });
+
+  it('preserves exact model names that contain slashes', async () => {
+    const response = await request([
+      'mode=text-token',
+      'models=fireworks%2Faccounts%2Ffireworks%2Fmodels%2Fllama-v3p3-70b-instruct',
+      'input=1',
+      'output=0',
+      'cacheRead=0',
+      'cacheWrite=0',
+    ].join('&'));
+    const body = await json<PricingResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.models[0].key).toBe('fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct');
+  });
+
+  it('returns explicit cache-read and cache-write components', async () => {
+    const response = await request([
+      'mode=text-token',
+      'models=anthropic%2Fclaude-sonnet-4-6',
+      'input=0',
+      'output=0',
+      'cacheRead=200',
+      'cacheWrite=100',
+    ].join('&'));
+    const body = await json<PricingResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.models[0]?.costs.cacheRead).toBeGreaterThan(0);
+    expect(body.models[0]?.costs.cacheWrite).toBeGreaterThan(0);
+    expect(body.models[0]?.costs.total).toBe(
+      Number(body.models[0]?.costs.cacheRead) + Number(body.models[0]?.costs.cacheWrite),
+    );
+  });
+
+  it('uses provider and model as deterministic tie-breakers', async () => {
+    const response = await request([
+      'mode=text-token',
+      'models=anthropic%2Fclaude-opus-4-6%2Canthropic%2Fclaude-opus-4-5',
+      'input=1',
+      'output=0',
+      'cacheRead=0',
+      'cacheWrite=0',
+    ].join('&'));
+    const body = await json<PricingResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.models.map((entry) => entry.key)).toEqual([
+      'anthropic/claude-opus-4-5',
+      'anthropic/claude-opus-4-6',
+    ]);
+  });
+
+  it.each([
+    ['', 'mode'],
+    [VALID_QUERY.replace('mode=text-token&', ''), 'mode'],
+    [VALID_QUERY.replace('input=1000', 'input='), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=-1'), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=1.5'), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=NaN'), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=Infinity'), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=null'), 'input'],
+    [VALID_QUERY.replace('input=1000', 'input=9007199254740992'), 'input'],
+    [VALID_QUERY.replace('mode=text-token', 'mode=image'), 'mode'],
+    [`${VALID_QUERY}&input=1`, 'input'],
+    [`${VALID_QUERY}&provider=anthropic`, 'provider'],
+  ])('rejects invalid or ambiguous query %s', async (query, field) => {
+    const response = await request(query);
+    const body = await json<ErrorResponse>(response);
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_PRICING_QUERY');
+    expect(body.error.field).toBe(field);
+  });
+
+  it('rejects a zero-work comparison', async () => {
+    const query = VALID_QUERY
+      .replace('input=1000', 'input=0')
+      .replace('output=500', 'output=0');
+    const response = await request(query);
+    const body = await json<ErrorResponse>(response);
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatchObject({ code: 'INVALID_PRICING_QUERY', field: 'usage' });
+  });
+
+  it('rejects duplicate and unknown exact model keys', async () => {
+    const duplicate = await request(VALID_QUERY.replace(
+      'anthropic%2Fclaude-sonnet-4-6%2Copenai%2Fgpt-4o',
+      'openai%2Fgpt-4o%2Copenai%2Fgpt-4o',
+    ));
+    expect(duplicate.status).toBe(400);
+    expect((await json<ErrorResponse>(duplicate)).error.code).toBe('INVALID_PRICING_QUERY');
+
+    const unknown = await request(VALID_QUERY.replace('openai%2Fgpt-4o', 'openai%2Fmissing-model'));
+    expect(unknown.status).toBe(400);
+    expect((await json<ErrorResponse>(unknown)).error.code).toBe('UNKNOWN_PRICING_MODEL');
+  });
+});

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -1,4 +1,4 @@
-import { PREFIXES, PRICING_DATA } from './pricing-data.js';
+import { PREFIXES, PRICING_DATA, UPDATED_AT } from './pricing-data.js';
 import type { CostBreakdown, ExtraCost, ExtraCostDimension, ProviderName, TokenUsage } from './types.js';
 
 export interface ExtraRateDefinition {
@@ -25,6 +25,7 @@ type PricingTable = Record<string, ModelPricing>;
 
 // pricing data loaded from pricing.json via generated pricing-data.ts
 const PRICING: Record<ProviderName, PricingTable> = {} as Record<ProviderName, PricingTable>;
+export const PRICING_UPDATED_AT = UPDATED_AT;
 
 for (const [provider, models] of Object.entries(PRICING_DATA)) {
   const table: PricingTable = {};

--- a/scripts/run-js-tests.mjs
+++ b/scripts/run-js-tests.mjs
@@ -38,6 +38,12 @@ const tests = [
   'test/quality-gate-contract-test.mjs',
   'test/release-workflow-contract-test.mjs',
 ];
+const typedTests = [
+  {
+    packageName: '@f3d1/llmkit-proxy',
+    file: 'test/pricing-route.test.ts',
+  },
+];
 
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -77,4 +83,9 @@ for (const testFile of tests) {
   run(process.execPath, [testFile]);
 }
 
-console.log(`\nJS_TEST_GATE PASS (${tests.length} test programs)`);
+for (const { packageName, file } of typedTests) {
+  console.log(`\nTEST ${packageName}/${file}`);
+  pnpm(['--filter', packageName, 'exec', 'vitest', 'run', file, '--environment', 'node']);
+}
+
+console.log(`\nJS_TEST_GATE PASS (${tests.length + typedTests.length} test programs)`);


### PR DESCRIPTION
﻿## Outcome

The public pricing endpoint now estimates only exact model keys selected by the caller. It no longer accepts invalid token counts or produces a global ranking across a snapshot whose model modality is unknown.

## What changed

- Require `mode=text-token`, exact `provider/model` keys, and all four token-count fields.
- Reject missing, duplicate, empty, negative, fractional, non-finite, unsafe, unknown, and all-zero requests.
- Cap each request at 20 exact model keys and preserve identifiers that contain `/`.
- Return snapshot boundaries, rate components, cost components, exclusions, and deterministic ordering.
- Move the public 30 RPM limit to the existing Durable Object and expire its stored state after the active window.
- Update public links and API documentation to the explicit query shape.

## Compatibility

This is an intentional breaking change to `GET /v1/pricing/compare`. Calls using the previous implicit all-model query return `400`. The endpoint remains unauthenticated.

## Proof

- 18 focused pricing-route tests: PASS
- Real Worker proof across isolate eviction, early alarm, and expiry cleanup: PASS
- 29-program JS gate: PASS
- 113 Python SDK tests: PASS
- Populated migration proof, 65 database tests, and schema lint: PASS
- Proxy production deployment dry-run: PASS
- Dashboard production build: PASS
- Independent adversarial review: no actionable findings
- Exact-head Linux `quality-pr`: PASS ([run 31675408962](https://github.com/smigolsmigol/llmkit/actions/runs/31675408962/job/94368796999))

The full Windows gate passes its functional, security, package, and database checks. Its documented host-sensitive latency shard passes alone at 11 ms median and 17 ms p95, but fails after the stress shards on this workstation. The thresholds are unchanged; native Linux CI is the release receipt, consistent with PR #163.

## Deployment order and boundaries

1. Merge only after exact-head CI and human approval.
2. Deploy the proxy before the dashboard so public links never depend on an older API contract.
3. Verify the served endpoint, then deploy the dashboard in a separate approved action.

This PR does not deploy, publish a package, change catalog values, change registry versions, or create a release. The catalog remains a 731-entry snapshot dated 2026-03-25 and does not encode modality.

Linear: F3D-47

